### PR TITLE
Add experiment with modelling failing communication channels

### DIFF
--- a/src/bmi/samplers/_tfp/__init__.py
+++ b/src/bmi/samplers/_tfp/__init__.py
@@ -7,9 +7,18 @@ from bmi.samplers._tfp._core import (
     transform,
 )
 
+from bmi.samplers._tfp._normal import (
+    construct_multivariate_normal_distribution,
+    MultivariateNormalDistribution,
+)
+
+from bmi.samplers._tfp._student import (
+    construct_multivariate_student_distribution,
+    MultivariateStudentDistribution,
+)
+
 # isort: on
-from bmi.samplers._tfp._normal import MultivariateNormalDistribution
-from bmi.samplers._tfp._student import MultivariateStudentDistribution
+from bmi.samplers._tfp._product import ProductDistribution
 from bmi.samplers._tfp._wrapper import FineSampler
 
 __all__ = [
@@ -20,5 +29,8 @@ __all__ = [
     "monte_carlo_mi_estimate",
     "MultivariateNormalDistribution",
     "MultivariateStudentDistribution",
+    "ProductDistribution",
     "FineSampler",
+    "construct_multivariate_normal_distribution",
+    "construct_multivariate_student_distribution",
 ]

--- a/src/bmi/samplers/_tfp/_normal.py
+++ b/src/bmi/samplers/_tfp/_normal.py
@@ -11,7 +11,7 @@ jtf = tfp.tf2jax
 tfd = tfp.distributions
 
 
-def _construct_multivariate_distribution(
+def construct_multivariate_normal_distribution(
     mean: jnp.ndarray, covariance: jnp.ndarray
 ) -> tfd.MultivariateNormalLinearOperator:
     # Lower triangular matrix such that `covariance = scale @ scale^T`
@@ -49,11 +49,11 @@ class MultivariateNormalDistribution(JointDistribution):
         # Now we need to define the TensorFlow Probability distributions
         # using the information provided
 
-        dist_joint = _construct_multivariate_distribution(mean=mean, covariance=covariance)
-        dist_x = _construct_multivariate_distribution(
+        dist_joint = construct_multivariate_normal_distribution(mean=mean, covariance=covariance)
+        dist_x = construct_multivariate_normal_distribution(
             mean=mean[:dim_x], covariance=covariance[:dim_x, :dim_x]
         )
-        dist_y = _construct_multivariate_distribution(
+        dist_y = construct_multivariate_normal_distribution(
             mean=mean[dim_x:], covariance=covariance[dim_x:, dim_x:]
         )
 

--- a/src/bmi/samplers/_tfp/_product.py
+++ b/src/bmi/samplers/_tfp/_product.py
@@ -1,0 +1,42 @@
+from tensorflow_probability.substrates import jax as tfp
+
+from bmi.samplers._tfp._core import JointDistribution
+
+jtf = tfp.tf2jax
+tfd = tfp.distributions
+
+
+class ProductDistribution(JointDistribution):
+    """From distributions P_X and P_Y creates a distribution
+
+        P_{XY} = P_X x P_Y
+
+    in which the variables X and Y are independent.
+
+    In particular,
+
+        I(X; Y) = 0
+
+    under this distribution.
+    """
+
+    def __init__(self, dist_x: tfd.Distribution, dist_y: tfd.Distribution) -> None:
+        dims_x = dist_x.event_shape_tensor()
+        dims_y = dist_y.event_shape_tensor()
+
+        assert len(dims_x) == 1
+        assert len(dims_y) == 1
+
+        dim_x = int(dims_x[0])
+        dim_y = int(dims_y[0])
+
+        dist_joint = tfd.Blockwise([dist_x, dist_y])
+
+        super().__init__(
+            dim_x=dim_x,
+            dim_y=dim_y,
+            dist_joint=dist_joint,
+            dist_x=dist_x,
+            dist_y=dist_y,
+            analytic_mi=0.0,
+        )

--- a/src/bmi/samplers/_tfp/_student.py
+++ b/src/bmi/samplers/_tfp/_student.py
@@ -11,7 +11,7 @@ jtf = tfp.tf2jax
 tfd = tfp.distributions
 
 
-def _construct_multivariate_distribution(
+def construct_multivariate_student_distribution(
     mean: jnp.ndarray,
     dispersion: jnp.ndarray,
     df: Union[int, float],
@@ -63,11 +63,13 @@ class MultivariateStudentDistribution(JointDistribution):
         # Now we need to define the TensorFlow Probability distributions
         # using the information provided
 
-        dist_joint = _construct_multivariate_distribution(mean=mean, dispersion=dispersion, df=df)
-        dist_x = _construct_multivariate_distribution(
+        dist_joint = construct_multivariate_student_distribution(
+            mean=mean, dispersion=dispersion, df=df
+        )
+        dist_x = construct_multivariate_student_distribution(
             mean=mean[:dim_x], dispersion=dispersion[:dim_x, :dim_x], df=df
         )
-        dist_y = _construct_multivariate_distribution(
+        dist_y = construct_multivariate_student_distribution(
             mean=mean[dim_x:], dispersion=dispersion[dim_x:, dim_x:], df=df
         )
 

--- a/tests/samplers/tfp/test_product.py
+++ b/tests/samplers/tfp/test_product.py
@@ -1,0 +1,31 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import bmi.samplers
+from bmi.samplers import fine
+
+
+def test_product_distribution(dim_x: int = 2, dim_y: int = 3, n_points: int = 10) -> None:
+    assert dim_y >= dim_x, "We construct canonical correlation matrix, so we want this constraint."
+
+    dist_dependent = fine.MultivariateNormalDistribution(
+        dim_x=dim_x,
+        dim_y=dim_y,
+        covariance=bmi.samplers.canonical_correlation(
+            jnp.full((dim_x,), fill_value=0.5), additional_y=dim_y - dim_x
+        ),
+    )
+    dist_independent = fine.ProductDistribution(
+        dist_x=dist_dependent.dist_x, dist_y=dist_dependent.dist_y
+    )
+
+    assert dist_independent.analytic_mi == pytest.approx(0.0)
+
+    xs, ys = dist_independent.sample(n_points=n_points, key=jax.random.PRNGKey(0))
+    pmis = dist_independent.pmi(xs, ys)
+
+    assert pmis.min() == pytest.approx(0.0)
+    assert pmis.max() == pytest.approx(0.0)
+
+    # TODO(Pawel): Test whether some summary statistics of the marginal distributions are the same

--- a/workflows/Mixtures/_benchmark_rules.smk
+++ b/workflows/Mixtures/_benchmark_rules.smk
@@ -1,0 +1,70 @@
+# SnakeMake workflow used to generate results
+import resource
+import yaml
+
+import pandas as pd
+
+from bmi.benchmark import run_estimator
+
+
+# ASSUMES THAT THE FOLLOWING ARE DECLARED:
+#   - ESTIMATORS: dict estimator_id -> estimator
+#   - TASKS: dict task_id -> task
+#   - N_SAMPLES: list of ints
+#   - SEEDS: list of ints
+
+rule results:
+    output: 'results.csv'
+    input:
+        expand(
+            'results/{estimator_id}/{task_id}/{n_samples}-{seed}.yaml',
+            estimator_id=ESTIMATORS,
+            task_id=TASKS,
+            n_samples=N_SAMPLES,
+            seed=SEEDS,
+        )
+    run:
+        results = []
+        for result_path in input:
+            with open(result_path) as f:
+                result = yaml.load(f, yaml.SafeLoader)
+                task = TASKS[result['task_id']]
+                result['mi_true'] = task.mutual_information
+                result['task_params'] = task.params
+                results.append(result)
+        pd.DataFrame(results).to_csv(str(output), index=False)
+
+
+# Sample task given a seed and number of samples.
+rule sample_task:
+    output: 'tasks/{task_id}/{n_samples}-{seed}.csv'
+    run:
+        task_id = wildcards.task_id
+        n_samples = int(wildcards.n_samples)
+        seed = int(wildcards.seed)
+        task = TASKS[task_id]
+        task.save_sample(str(output), n_samples, seed)
+
+
+# Apply estimator to sample
+rule apply_estimator:
+    output: 'results/{estimator_id}/{task_id}/{n_samples}-{seed}.yaml'
+    input: 'tasks/{task_id}/{n_samples}-{seed}.csv'
+    run:
+        estimator_id = wildcards.estimator_id
+        estimator = ESTIMATORS[estimator_id]
+        task_id = wildcards.task_id
+        seed = int(wildcards.seed)
+        
+        # this should be about ~4GiB
+        resource.setrlimit(resource.RLIMIT_DATA, (1<<33, 1<<33))
+
+        result = run_estimator(
+            estimator=estimator,
+            estimator_id=estimator_id,
+            sample_path=str(input),
+            task_id=task_id,
+            seed=seed,
+        )
+        result.dump(str(output))
+

--- a/workflows/Mixtures/_benchmark_rules.smk
+++ b/workflows/Mixtures/_benchmark_rules.smk
@@ -1,17 +1,33 @@
 # SnakeMake workflow used to generate results
+# ASSUMES THAT THE FOLLOWING ARE DECLARED:
+#   - ESTIMATORS: dict estimator_id -> estimator
+#   - UNSCALED_TASKS: dict task_id -> task
+#   - N_SAMPLES: list of ints
+#   - SEEDS: list of ints
+
 import resource
 import yaml
 
 import pandas as pd
 
+import bmi
 from bmi.benchmark import run_estimator
+from bmi.benchmark.tasks import transform_rescale
 
 
-# ASSUMES THAT THE FOLLOWING ARE DECLARED:
-#   - ESTIMATORS: dict estimator_id -> estimator
-#   - TASKS: dict task_id -> task
-#   - N_SAMPLES: list of ints
-#   - SEEDS: list of ints
+def scale_tasks(tasks: dict[str, bmi.Task]) -> dict[str, bmi.Task]:
+    """Auxiliary method used to rescale (whiten) each task in the list,
+    without changing its name nor id."""
+    return {
+        key: transform_rescale(
+            base_task=base_task,
+            task_name=base_task.name,
+            task_id=base_task.id,
+        )
+        for key, base_task in tasks.items()
+    }
+
+TASKS = scale_tasks(UNSCALED_TASKS)
 
 rule results:
     output: 'results.csv'

--- a/workflows/Mixtures/cool_tasks.smk
+++ b/workflows/Mixtures/cool_tasks.smk
@@ -1,19 +1,11 @@
 """Demonstration of the capabilities of the fine distribution family."""
-import bmi.estimators as estimators
-from bmi.benchmark.tasks import transform_rescale
-import resource
-import yaml
-
-import pandas as pd
-
-from bmi.benchmark import run_estimator
-
 import numpy as np
-import jax.numpy as jnp
-import matplotlib.pyplot as plt
+import pandas as pd
 import matplotlib
 from subplots_from_axsize import subplots_from_axsize
 matplotlib.use("agg")
+
+import jax.numpy as jnp
 
 import bmi
 from bmi.samplers import fine
@@ -147,7 +139,7 @@ ESTIMATOR_NAMES = {
 }
 assert set(ESTIMATOR_NAMES.keys()) == set(ESTIMATORS.keys())
 
-TASKS_UNSCALED = {
+UNSCALED_TASKS = {
     "X": bmi.benchmark.Task(
         sampler=x_sampler,
         task_id="X",
@@ -169,20 +161,6 @@ TASKS_UNSCALED = {
         task_name="Balls",
     ),
 }
-
-def scale_tasks(tasks: dict[str, bmi.Task]) -> dict[str, bmi.Task]:
-    """Auxiliary method used to rescale (whiten) each task in the list,
-    without changing its name nor id."""
-    return {
-        key: transform_rescale(
-            base_task=base_task,
-            task_name=base_task.name,
-            task_id=base_task.id,
-        )
-        for key, base_task in tasks.items()
-    }
-
-TASKS = scale_tasks(TASKS_UNSCALED)
 
 
 # === WORKDIR ===

--- a/workflows/Mixtures/cool_tasks.smk
+++ b/workflows/Mixtures/cool_tasks.smk
@@ -285,58 +285,5 @@ rule plot_results:
         ax.set_ylabel('Mutual information [nats]')
         fig.savefig(str(output))
 
-rule results:
-    output: 'results.csv'
-    input:
-        expand(
-            'results/{estimator_id}/{task_id}/{n_samples}-{seed}.yaml',
-            estimator_id=ESTIMATORS,
-            task_id=TASKS,
-            n_samples=N_SAMPLES,
-            seed=SEEDS,
-        )
-    run:
-        results = []
-        for result_path in input:
-            with open(result_path) as f:
-                result = yaml.load(f, yaml.SafeLoader)
-                task = TASKS[result['task_id']]
-                result['mi_true'] = task.mutual_information
-                result['task_params'] = task.params
-                results.append(result)
-        pd.DataFrame(results).to_csv(str(output), index=False)
 
-
-# Sample task given a seed and number of samples.
-rule sample_task:
-    output: 'tasks/{task_id}/{n_samples}-{seed}.csv'
-    run:
-        task_id = wildcards.task_id
-        n_samples = int(wildcards.n_samples)
-        seed = int(wildcards.seed)
-        task = TASKS[task_id]
-        task.save_sample(str(output), n_samples, seed)
-
-
-# Apply estimator to sample
-rule apply_estimator:
-    output: 'results/{estimator_id}/{task_id}/{n_samples}-{seed}.yaml'
-    input: 'tasks/{task_id}/{n_samples}-{seed}.csv'
-    run:
-        estimator_id = wildcards.estimator_id
-        estimator = ESTIMATORS[estimator_id]
-        task_id = wildcards.task_id
-        seed = int(wildcards.seed)
-        
-        # this should be about ~4GiB
-        resource.setrlimit(resource.RLIMIT_DATA, (1<<33, 1<<33))
-
-        result = run_estimator(
-            estimator=estimator,
-            estimator_id=estimator_id,
-            sample_path=str(input),
-            task_id=task_id,
-            seed=seed,
-        )
-        result.dump(str(output))
-
+include: "_benchmark_rules.smk"

--- a/workflows/Mixtures/outliers.smk
+++ b/workflows/Mixtures/outliers.smk
@@ -67,10 +67,10 @@ CHANGE_MIXING_SETUPS = {
 }
 
 
-VARIANCES = [0.001, 0.05, 0.1, 0.3, 0.5, 0.8, 1.0, 1.2, 2.0, 4.0, 10.0]
-ALPHAS = [0.001, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5]
+VARIANCES = 2**np.concatenate([np.arange(-7, -2, 1.0), np.arange(-2, 4, 0.5), np.arange(4, 8, 1.0)])
+ALPHAS = [0.001, 0.01, 0.05, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5]
 
-UNSCALED_TASKS = {}
+MIXING_TASKS = {}
 # Add mixing tasks
 for setup_name, setup in CHANGE_MIXING_SETUPS.items():
     for alpha in ALPHAS:
@@ -81,9 +81,10 @@ for setup_name, setup in CHANGE_MIXING_SETUPS.items():
             task_name=f"mixing-{setup_name}-{alpha}",
             task_params={"mixing": alpha},
         )
-        UNSCALED_TASKS[task.id] = task
+        MIXING_TASKS[task.id] = task
 
 # Add the task with changing the variance
+VARIANCE_TASKS = {}
 for variance in VARIANCES:
     dist_noise_variance =  fine.ProductDistribution(
         dist_x=dist_signal_gauss.dist_x,
@@ -105,8 +106,9 @@ for variance in VARIANCES:
         task_name=f"variance-{variance}",
         task_params={"variance": variance},
     )
-    UNSCALED_TASKS[task.id] = task
+    VARIANCE_TASKS[task.id] = task
 
+UNSCALED_TASKS = {**MIXING_TASKS, **VARIANCE_TASKS}
 
 ESTIMATORS = {
     "KSG": bmi.estimators.KSGEnsembleFirstEstimator(neighborhoods=(10,)),
@@ -122,6 +124,7 @@ rule all:
     input:
         mixing_ground_truths = expand("{setup}/mixing_ground_truths.done", setup=CHANGE_MIXING_SETUPS.keys()),
         estimates = "results.csv"
+
 
 
 rule make_one_setup:

--- a/workflows/Mixtures/outliers.smk
+++ b/workflows/Mixtures/outliers.smk
@@ -1,0 +1,232 @@
+"""This workflow tests how the performance of different estimators changes
+when mixing with "outlier" distribution is performed.
+"""
+from typing import Callable, Optional
+import dataclasses
+import json
+
+import numpy as np
+import pandas as pd
+import matplotlib
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import jax
+import jax.numpy as jnp
+
+import bmi
+from bmi.samplers import fine
+
+
+# === WORKDIR ===
+workdir: "generated/mixtures/outliers"
+
+
+@dataclasses.dataclass
+class ChangeMixingSetup:
+    dist_true: fine.JointDistribution
+    dist_noise: fine.JointDistribution
+
+    def mixture(self, alpha: float) -> fine.JointDistribution:
+        """Return a mixture of the two distributions.
+        
+        Args:
+            alpha: contamination level, i.e. the probability of the noise distribution
+        """
+        return fine.mixture(
+            components=[self.dist_true, self.dist_noise],
+            proportions=jnp.asarray([1.0 - alpha, alpha]),
+        )
+
+
+dist_signal_gauss = fine.MultivariateNormalDistribution(
+    dim_x=2,
+    dim_y=2,
+    covariance=bmi.samplers.SparseLVMParametrization(dim_x=2, dim_y=2, n_interacting=2, beta=0.1, lambd=2.0).correlation
+)
+
+covariance_noise = 0.3 * jnp.eye(dist_signal_gauss.dim_y)
+dist_gaussian_noise = fine.ProductDistribution(
+    dist_x=dist_signal_gauss.dist_x,
+    dist_y=fine.construct_multivariate_normal_distribution(mean=jnp.zeros(dist_signal_gauss.dim_y), covariance=covariance_noise),
+)
+
+# We will now define a Student distribution with the same covariance matrix
+student_dof = 3.0
+assert student_dof > 2.0
+student_dispersion = covariance_noise * (student_dof - 2.0) / student_dof
+
+dist_student_noise = fine.ProductDistribution(
+    dist_x=dist_signal_gauss.dist_x,
+    dist_y=fine.construct_multivariate_student_distribution(mean=jnp.zeros(dist_signal_gauss.dim_y), dispersion=student_dispersion, df=student_dof),
+)
+
+CHANGE_MIXING_SETUPS = {
+    "Gauss-Gauss": ChangeMixingSetup(dist_true=dist_signal_gauss, dist_noise=dist_gaussian_noise),
+    "Gauss-Student": ChangeMixingSetup(dist_true=dist_signal_gauss, dist_noise=dist_student_noise),
+}
+
+
+VARIANCES = [0.001, 0.05, 0.1, 0.3, 0.5, 0.8, 1.0, 1.2, 2.0, 4.0, 10.0]
+ALPHAS = [0.001, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5]
+
+UNSCALED_TASKS = {}
+# Add mixing tasks
+for setup_name, setup in CHANGE_MIXING_SETUPS.items():
+    for alpha in ALPHAS:
+        sampler = fine.FineSampler(dist=setup.mixture(alpha=alpha), mi_estimate_sample=100_000)
+        task = bmi.Task(
+            sampler=sampler,
+            task_id=f"mixing-{setup_name}-{alpha}",
+            task_name=f"mixing-{setup_name}-{alpha}",
+            task_params={"mixing": alpha},
+        )
+        UNSCALED_TASKS[task.id] = task
+
+# Add the task with changing the variance
+for variance in VARIANCES:
+    dist_noise_variance =  fine.ProductDistribution(
+        dist_x=dist_signal_gauss.dist_x,
+        dist_y=fine.construct_multivariate_normal_distribution(
+            mean=jnp.zeros(dist_signal_gauss.dim_y),
+            covariance=variance * jnp.eye(dist_signal_gauss.dim_y)
+        ),
+    )
+    sampler = fine.FineSampler(
+        dist=fine.mixture(
+            proportions=jnp.array([0.9, 0.1]),
+            components=[dist_signal_gauss, dist_noise_variance],
+        ),
+        mi_estimate_sample=100_000,
+    )
+    task = bmi.Task(
+        sampler=sampler,
+        task_id=f"variance-{variance}",
+        task_name=f"variance-{variance}",
+        task_params={"variance": variance},
+    )
+    UNSCALED_TASKS[task.id] = task
+
+
+ESTIMATORS = {
+    "KSG": bmi.estimators.KSGEnsembleFirstEstimator(neighborhoods=(10,)),
+    "CCA": bmi.estimators.CCAMutualInformationEstimator(),
+    "InfoNCE": bmi.estimators.InfoNCEEstimator(),
+    "MINE": bmi.estimators.MINEEstimator(),
+}
+SEEDS = list(range(10))
+N_SAMPLES = [5000]
+
+
+rule all:
+    input:
+        mixing_ground_truths = expand("{setup}/mixing_ground_truths.done", setup=CHANGE_MIXING_SETUPS.keys()),
+        estimates = "results.csv"
+
+
+rule make_one_setup:
+    output: touch("{setup}/mixing_ground_truths.done")
+    input:
+        signal_estimate = "{setup}/signal.json",
+        mixing_ground_truth = expand("{setup}/_mixed_ground_truth/summaries/{mixing}.json", mixing=ALPHAS, allow_missing=True)
+
+
+rule estimate_mi_mixed_all_seeds:
+    output: "{setup}/_mixed_ground_truth/summaries/{mixing}.json"
+    input: expand("{setup}/_mixed_ground_truth/seeds/{mixing}-{seed}.json", seed=SEEDS, allow_missing=True) 
+    run:
+        estim_dicts = []
+        for inp in input:
+            with open(inp) as fh:
+                estim_dicts.append(json.load(fh))
+
+        mi_mean = np.mean([estim["mi"] for estim in estim_dicts])
+        mi_std = np.std([estim["mi"] for estim in estim_dicts], ddof=1)
+        mi_stderr_mean = np.mean([estim["mi_stderr"] for estim in estim_dicts])
+
+        with open(str(output), "w") as fh:
+            json.dump({
+                "mi_mean": float(mi_mean),
+                "mi_std": float(mi_std),
+                "mi_stderr_mean": float(mi_stderr_mean),
+                "mixing": float(wildcards.mixing),
+                "samples": estim_dicts,
+            },
+            fh,
+            indent=4,
+        )
+
+rule estimate_mi_mixed_one_seed:
+    """Estimate MI in the signal distribution for one seed.
+    This is not dependent on the mixing."""
+    output: "{setup}/_mixed_ground_truth/seeds/{mixing}-{seed}.json"
+    run:
+        N_SAMPLES: int = 100_000
+        setup = CHANGE_MIXING_SETUPS[wildcards.setup]
+        dist = setup.mixture(alpha=float(wildcards.mixing))
+
+        key = jax.random.PRNGKey(int(wildcards.seed))
+        mi, mi_stderr = fine.monte_carlo_mi_estimate(key=key, dist=dist, n=N_SAMPLES)
+        mi, mi_stderr = float(mi), float(mi_stderr)
+        with open(str(output), "w") as fh:
+            json.dump({
+                "mi": mi,
+                "mi_stderr": mi_stderr,
+                "mixing": float(wildcards.mixing),
+            },
+            fh,
+            indent=4,
+        )
+
+
+rule estimate_mi_signal_one_seed:
+    """Estimate MI in the signal distribution for one seed.
+    This is not dependent on the mixing."""
+    output: "{setup}/_signal_seeds/{seed}.json"
+    run:
+        N_SAMPLES: int = 100_000
+        setup = CHANGE_MIXING_SETUPS[wildcards.setup]
+        dist = setup.dist_true
+
+        key = jax.random.PRNGKey(int(wildcards.seed))
+        mi, mi_stderr = fine.monte_carlo_mi_estimate(key=key, dist=dist, n=N_SAMPLES)
+        mi, mi_stderr = float(mi), float(mi_stderr)
+        with open(str(output), "w") as fh:
+            json.dump({
+                "mi": mi,
+                "mi_stderr": mi_stderr,
+            },
+            fh,
+            indent=4,
+        )
+
+N_SEEDS_GROUND_TRUTH: int = 2
+rule estimate_mi_signal_all_seeds:
+    """Estimate MI in the signal distribution for all seeds, assembling other runs."""
+    output: "{setup}/signal.json"
+    input: expand("{setup}/_signal_seeds/{seed}.json", seed=range(N_SEEDS_GROUND_TRUTH), allow_missing=True)
+    run:
+        estim_dicts = []
+        for inp in input:
+            with open(inp) as fh:
+                estim_dicts.append(json.load(fh))
+
+        mi_analytic = CHANGE_MIXING_SETUPS[wildcards.setup].dist_true.analytic_mi
+        mi_mean = np.mean([estim["mi"] for estim in estim_dicts])
+        mi_std = np.std([estim["mi"] for estim in estim_dicts], ddof=1)
+        mi_stderr_mean = np.mean([estim["mi_stderr"] for estim in estim_dicts])
+
+        with open(str(output), "w") as fh:
+            json.dump({
+                "mi_analytic": float(mi_analytic),
+                "mi_mean": float(mi_mean),
+                "mi_std": float(mi_std),
+                "mi_stderr_mean": float(mi_stderr_mean),
+                "samples": estim_dicts,
+            },
+            fh,
+            indent=4,
+        )
+
+
+include: "_benchmark_rules.smk"


### PR DESCRIPTION
This PR turned out to be trickier and larger than expected. Anyway, here it goes with the following changes:

  - We now use auxiliary workflow for our typical benchmark rules. Note that it now scales tasks automatically, so that `UNSCALED_TASKS` should be declared rather than `TASKS`. In particular, look how much `cool_tasks.smk` has shrunk.
  - It adds a product distribution (for independent random variables) to the `fine` subpackage. It also adds to the public API utilities for creating TensorFlow Probability's multivariate normal and Student distributions. (Which were previously hidden).
  - It adds the workflow for studying outliers/failing communication channels. It's ugly, but it seems that it does the job.

If you think it's ready to be merged, please merge – I will have little coding time until Wednesday evening...