### PR TITLE
Neural batch size error more informative

### DIFF
--- a/src/bmi/estimators/neural/_estimators.py
+++ b/src/bmi/estimators/neural/_estimators.py
@@ -138,7 +138,10 @@ class NeuralEstimatorBase(IMutualInformationPointEstimator):
             xs, ys, train_size=self._params.train_test_split, key=key_split
         )
 
-        if len(xs_train):
+        if self._params.batch_size > len(xs_train):
+            if self._verbose:
+                print("ERROR: Batch size larger than train dataset.")
+
             return EstimateResult(
                 mi_estimate=float("nan"),
                 additional_information={"batch_size_larger_than_train": True},

--- a/src/bmi/estimators/neural/_estimators.py
+++ b/src/bmi/estimators/neural/_estimators.py
@@ -138,6 +138,12 @@ class NeuralEstimatorBase(IMutualInformationPointEstimator):
             xs, ys, train_size=self._params.train_test_split, key=key_split
         )
 
+        if len(xs_train):
+            return EstimateResult(
+                mi_estimate=float("nan"),
+                additional_information={"batch_size_larger_than_train": True},
+            )
+
         # initialize critic
         critic = self._critic_factory(key_init, xs_train.shape[-1], ys_train.shape[-1])
 

--- a/src/bmi/estimators/neural/_mine_estimator.py
+++ b/src/bmi/estimators/neural/_mine_estimator.py
@@ -330,7 +330,7 @@ class MINEEstimator(IMutualInformationPointEstimator):
         )
 
         if self._params.batch_size > len(xs_train):
-            if self.verbose:
+            if self._verbose:
                 print("ERROR: Batch size larger than train dataset.")
 
             return EstimateResult(

--- a/src/bmi/estimators/neural/_mine_estimator.py
+++ b/src/bmi/estimators/neural/_mine_estimator.py
@@ -329,6 +329,12 @@ class MINEEstimator(IMutualInformationPointEstimator):
             xs, ys, train_size=self._params.train_test_split, key=key_split
         )
 
+        if len(xs_train):
+            return EstimateResult(
+                mi_estimate=float("nan"),
+                additional_information={"batch_size_larger_than_train": True},
+            )
+
         # initialize critic
         critic = self._create_critic(dim_x=space.dim_x, dim_y=space.dim_y, key=key_init)
 

--- a/src/bmi/estimators/neural/_mine_estimator.py
+++ b/src/bmi/estimators/neural/_mine_estimator.py
@@ -329,7 +329,10 @@ class MINEEstimator(IMutualInformationPointEstimator):
             xs, ys, train_size=self._params.train_test_split, key=key_split
         )
 
-        if len(xs_train):
+        if self._params.batch_size > len(xs_train):
+            if self.verbose:
+                print("ERROR: Batch size larger than train dataset.")
+
             return EstimateResult(
                 mi_estimate=float("nan"),
                 additional_information={"batch_size_larger_than_train": True},

--- a/workflows/benchmark/_utils.py
+++ b/workflows/benchmark/_utils.py
@@ -105,7 +105,7 @@ def create_benchmark_table(results, n_samples=None, converged_only=False):
         )
         if converged_only:
             styler.set_caption(
-                "Estimates smaller than 10% of the maximal estimate are excluded."
+                "Estimates smaller than 10% of the maximal estimate are excluded. "
                 "This can help neural estimators which sometimes fail to converge."
             )
         return styler
@@ -154,7 +154,7 @@ def create_convergance_table(results, n_samples=None):
             cmap="gray",
         )
         styler.set_caption(
-            "Estimates higher than 10% of the maximal estimate are considered"
+            "Estimates higher than 10% of the maximal estimate are considered "
             "converged. This table shows the percentage of converged estimates."
         )
         return styler


### PR DESCRIPTION
Previously it simply crashed. In benchmark results that would kinda work, because the stack trace would be appended, but now it is definitely better.