### PR TITLE
Benchmark v2

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 99
-ignore = W503
+ignore = W503,E202,E251
 exclude =
     .git,
     __pycache__,

--- a/scripts/Beyond_Normal/figures/student/correction.py
+++ b/scripts/Beyond_Normal/figures/student/correction.py
@@ -11,9 +11,9 @@ of the degrees of freedom for several dimensions.
 from typing import cast
 
 import matplotlib.pyplot as plt
+from subplots_from_axsize import subplots_from_axsize
 
-import bmi.api as bmi
-from bmi.plot_utils.subplots_from_axsize import subplots_from_axsize
+import bmi
 
 
 def correction(df: int, m: int, n: int) -> float:
@@ -43,7 +43,7 @@ def main() -> None:
     for i, (m, n) in enumerate(mns):
         values = [correction(df=df, m=m, n=n) for df in nus]
         # ax.scatter(nus, values, s=4, marker=MARKER_LIST[i], c=f"C{i+1}")
-        ax.plot(nus, values, c=f"C{i+1}", label=f"$m={m}$,\t$n={n}$")
+        ax.plot(nus, values, c=f"C{i + 1}", label=f"$m={m}$,\t$n={n}$")
 
     ax.spines[["right", "top"]].set_visible(False)
     ax.set_xlabel("Degrees of freedom")

--- a/src/bmi/benchmark/task.py
+++ b/src/bmi/benchmark/task.py
@@ -29,13 +29,19 @@ class Task:
         task_params: Optional[dict] = None,
     ):
         self.sampler = sampler
-        self.metadata = TaskMetadata(
-            task_id=task_id,
-            task_name=task_name,
+        self._task_id = task_id
+        self._task_name = task_name
+        self._task_params = task_params
+
+    @property
+    def metadata(self) -> TaskMetadata:
+        return TaskMetadata(
+            task_id=self._task_id,
+            task_name=self._task_name,
             dim_x=self.sampler.dim_x,
             dim_y=self.sampler.dim_y,
             mi_true=self.sampler.mutual_information(),
-            task_params=task_params or dict(),
+            task_params=self._task_params or dict(),
         )
 
     @property

--- a/src/bmi/benchmark/tasks/__init__.py
+++ b/src/bmi/benchmark/tasks/__init__.py
@@ -12,6 +12,15 @@ from bmi.benchmark.tasks.multinormal import (
     task_multinormal_lvm,
 )
 
+from bmi.benchmark.tasks.mixtures import (
+    task_x,
+    task_ai,
+    task_waves,
+    task_galaxy,
+    task_concentric_multinormal,
+    task_multinormal_sparse_w_inliers,
+)
+
 # isort: on
 from bmi.benchmark.tasks.normal_cdf import transform_normal_cdf_task
 from bmi.benchmark.tasks.rotate import transform_rotate_task
@@ -44,6 +53,12 @@ __all__ = [
     "task_multinormal_dense",
     "task_multinormal_sparse",
     "task_multinormal_2pair",
+    "task_x",
+    "task_ai",
+    "task_waves",
+    "task_galaxy",
+    "task_concentric_multinormal",
+    "task_multinormal_sparse_w_inliers",
     "task_student_dense",
     "task_student_sparse",
     "task_student_2pair",

--- a/src/bmi/benchmark/tasks/mixtures.py
+++ b/src/bmi/benchmark/tasks/mixtures.py
@@ -1,0 +1,36 @@
+import jax.numpy as jnp
+
+import bmi.samplers as samplers
+from bmi.benchmark.task import Task
+from bmi.samplers import fine
+
+_MC_MI_ESTIMATE_SAMPLE = 100_000
+
+
+def task_x(
+    gaussian_correlation=0.9,
+    mi_estimate_sample=_MC_MI_ESTIMATE_SAMPLE,
+) -> Task:
+
+    x_dist = fine.mixture(
+        proportions=jnp.array([0.5, 0.5]),
+        components=[
+            fine.MultivariateNormalDistribution(
+                covariance=samplers.canonical_correlation([x * gaussian_correlation]),
+                mean=jnp.zeros(2),
+                dim_x=1,
+                dim_y=1,
+            )
+            for x in [-1, 1]
+        ],
+    )
+    x_sampler = fine.FineSampler(x_dist, mi_estimate_sample=mi_estimate_sample)
+
+    return Task(
+        sampler=x_sampler,
+        task_id=f"1v1-X-{gaussian_correlation}",
+        task_name="X 1 × 1",
+        task_params={
+            "gaussian_correlation": gaussian_correlation,
+        },
+    )

--- a/src/bmi/benchmark/tasks/mixtures.py
+++ b/src/bmi/benchmark/tasks/mixtures.py
@@ -182,3 +182,88 @@ def task_waves(
             "wave_frequency": wave_frequency,
         },
     )
+
+
+def task_concentric_multinormal(
+    dim_x,
+    n_components=3,
+    mi_estimate_sample=_MC_MI_ESTIMATE_SAMPLE,
+) -> Task:
+    """Isotropic Gaussians with varying standard deviation."""
+
+    assert n_components > 0
+
+    dist = fine.mixture(
+        proportions=jnp.ones(n_components) / n_components,
+        components=[
+            fine.MultivariateNormalDistribution(
+                covariance=jnp.diag(jnp.array(dim_x * [i**2] + [0.0001])),
+                mean=jnp.array(dim_x * [0.0] + [1.0 * i]),
+                dim_x=dim_x,
+                dim_y=1,
+            )
+            for i in range(1, 1 + n_components)
+        ],
+    )
+    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+
+    return Task(
+        sampler=sampler,
+        task_id=f"{dim_x}v1-concentric_gaussians-{n_components}",
+        task_name=f"Concentric {dim_x} × 1",
+        task_params={
+            "n_components": n_components,
+        },
+    )
+
+
+def task_multinormal_sparse_w_inliers(
+    dim_x,
+    dim_y,
+    n_interacting: int = 2,
+    strength: float = 2.0,
+    inlier_fraction: float = 0.2,
+    mi_estimate_sample=_MC_MI_ESTIMATE_SAMPLE,
+) -> Task:
+
+    assert 0.0 <= inlier_fraction <= 1.0
+
+    params = samplers.GaussianLVMParametrization(
+        dim_x=dim_x,
+        dim_y=dim_y,
+        n_interacting=n_interacting,
+        alpha=0.0,
+        lambd=strength,
+        beta_x=0.0,
+        eta_x=strength,
+    )
+
+    signal_dist = fine.MultivariateNormalDistribution(
+        dim_x=dim_x,
+        dim_y=dim_y,
+        covariance=params.correlation,
+    )
+
+    noise_dist = fine.ProductDistribution(
+        dist_x=signal_dist.dist_x,
+        dist_y=signal_dist.dist_y,
+    )
+
+    dist = fine.mixture(
+        proportions=jnp.array([1 - inlier_fraction, inlier_fraction]),
+        components=[signal_dist, noise_dist],
+    )
+
+    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+
+    task_id = f"mult-sparse-w-inliers-{dim_x}-{dim_y}-{n_interacting}-{strength}-{inlier_fraction}"
+    return Task(
+        sampler=sampler,
+        task_id=task_id,
+        task_name=f"Multinormal {dim_x} × {dim_y} (sparse, {inlier_fraction:.0%} inliers)",
+        task_params={
+            "n_interacting": n_interacting,
+            "strength": strength,
+            "inlier_fraction": inlier_fraction,
+        },
+    )

--- a/src/bmi/benchmark/tasks/mixtures.py
+++ b/src/bmi/benchmark/tasks/mixtures.py
@@ -1,6 +1,8 @@
 import jax.numpy as jnp
+import numpy as np
 
 import bmi.samplers as samplers
+import bmi.transforms as transforms
 from bmi.benchmark.task import Task
 from bmi.samplers import fine
 
@@ -11,8 +13,9 @@ def task_x(
     gaussian_correlation=0.9,
     mi_estimate_sample=_MC_MI_ESTIMATE_SAMPLE,
 ) -> Task:
+    """The X distribution."""
 
-    x_dist = fine.mixture(
+    dist = fine.mixture(
         proportions=jnp.array([0.5, 0.5]),
         components=[
             fine.MultivariateNormalDistribution(
@@ -24,13 +27,158 @@ def task_x(
             for x in [-1, 1]
         ],
     )
-    x_sampler = fine.FineSampler(x_dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     return Task(
-        sampler=x_sampler,
+        sampler=sampler,
         task_id=f"1v1-X-{gaussian_correlation}",
         task_name="X 1 × 1",
         task_params={
             "gaussian_correlation": gaussian_correlation,
+        },
+    )
+
+
+def task_ai(
+    mi_estimate_sample=_MC_MI_ESTIMATE_SAMPLE,
+) -> Task:
+    """The AI distribution."""
+
+    corr = 0.95
+    var_x = 0.04
+
+    dist = fine.mixture(
+        proportions=jnp.full(6, fill_value=1 / 6),
+        components=[
+            # I components
+            fine.MultivariateNormalDistribution(
+                dim_x=1,
+                dim_y=1,
+                mean=jnp.array([1.0, 0.0]),
+                covariance=np.diag([0.01, 0.2]),
+            ),
+            fine.MultivariateNormalDistribution(
+                dim_x=1,
+                dim_y=1,
+                mean=jnp.array([1.0, 1]),
+                covariance=np.diag([0.05, 0.001]),
+            ),
+            fine.MultivariateNormalDistribution(
+                dim_x=1,
+                dim_y=1,
+                mean=jnp.array([1.0, -1]),
+                covariance=np.diag([0.05, 0.001]),
+            ),
+            # A components
+            fine.MultivariateNormalDistribution(
+                dim_x=1,
+                dim_y=1,
+                mean=jnp.array([-0.8, -0.2]),
+                covariance=np.diag([0.03, 0.001]),
+            ),
+            fine.MultivariateNormalDistribution(
+                dim_x=1,
+                dim_y=1,
+                mean=jnp.array([-1.2, 0.0]),
+                covariance=jnp.array(
+                    [[var_x, jnp.sqrt(var_x * 0.2) * corr], [jnp.sqrt(var_x * 0.2) * corr, 0.2]]
+                ),
+            ),
+            fine.MultivariateNormalDistribution(
+                dim_x=1,
+                dim_y=1,
+                mean=jnp.array([-0.4, 0.0]),
+                covariance=jnp.array(
+                    [[var_x, -jnp.sqrt(var_x * 0.2) * corr], [-jnp.sqrt(var_x * 0.2) * corr, 0.2]]
+                ),
+            ),
+        ],
+    )
+    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+
+    return Task(
+        sampler=sampler,
+        task_id="1v1-AI",
+        task_name="AI 1 × 1",
+    )
+
+
+def task_galaxy(
+    speed=0.5,
+    distance=3.0,
+    mi_estimate_sample=_MC_MI_ESTIMATE_SAMPLE,
+) -> Task:
+    """The Galaxy distribution."""
+
+    balls_mixt = fine.mixture(
+        proportions=jnp.array([0.5, 0.5]),
+        components=[
+            fine.MultivariateNormalDistribution(
+                covariance=samplers.canonical_correlation([0.0], additional_y=1),
+                mean=jnp.array([x, x, x]) * distance / 2,
+                dim_x=2,
+                dim_y=1,
+            )
+            for x in [-1, 1]
+        ],
+    )
+
+    base_sampler = fine.FineSampler(balls_mixt, mi_estimate_sample=mi_estimate_sample)
+    a = jnp.array([[0, -1], [1, 0]])
+    spiral = transforms.Spiral(a, speed=speed)
+
+    sampler = samplers.TransformedSampler(base_sampler, transform_x=spiral)
+
+    return Task(
+        sampler=sampler,
+        task_id=f"2v1-galaxy-{speed}-{distance}",
+        task_name="Galaxy 2 × 1",
+        task_params={
+            "speed": speed,
+            "distance": distance,
+        },
+    )
+
+
+def task_waves(
+    n_components=12,
+    wave_amplitude=5.0,
+    wave_frequency=3.0,
+    mi_estimate_sample=_MC_MI_ESTIMATE_SAMPLE,
+) -> Task:
+    """The Waves distribution."""
+
+    assert n_components > 0
+
+    base_dist = fine.mixture(
+        proportions=jnp.ones(n_components) / n_components,
+        components=[
+            fine.MultivariateNormalDistribution(
+                covariance=jnp.diag(jnp.array([0.1, 1.0, 0.1])),
+                mean=jnp.array([x, 0, x % 4]) * 1.5,
+                dim_x=2,
+                dim_y=1,
+            )
+            for x in range(n_components)
+        ],
+    )
+    base_sampler = fine.FineSampler(base_dist, mi_estimate_sample=mi_estimate_sample)
+    aux_sampler = samplers.TransformedSampler(
+        base_sampler,
+        transform_x=lambda x: x
+        + jnp.array([wave_amplitude, 0.0]) * jnp.sin(wave_frequency * x[1]),
+    )
+    sampler = samplers.TransformedSampler(
+        aux_sampler, transform_x=lambda x: jnp.array([0.1 * x[0] - 0.8, 0.5 * x[1]])
+    )
+
+    return Task(
+        sampler=sampler,
+        task_id=f"2v1-waves-{n_components}-{wave_amplitude}-{wave_frequency}",
+        task_name="Waves 2 × 1",
+        task_params={
+            "n_components": n_components,
+            "wave_amplitude": wave_amplitude,
+            "wave_frequency": wave_frequency,
         },
     )

--- a/src/bmi/samplers/_matrix_utils.py
+++ b/src/bmi/samplers/_matrix_utils.py
@@ -1,7 +1,7 @@
 """Utilities for creating dispersion matrices."""
 
 import dataclasses
-from typing import Optional
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -73,7 +73,9 @@ def parametrised_correlation_matrix(
     return corr_matrix
 
 
-def canonical_correlation(rho: np.ndarray, additional_y: int = 0) -> np.ndarray:
+def canonical_correlation(
+    rho: Union[np.ndarray, List[float]], additional_y: int = 0
+) -> np.ndarray:
     """Constructs a covariance matrix given by canonical correlations.
 
     Namely,

--- a/src/bmi/samplers/_matrix_utils.py
+++ b/src/bmi/samplers/_matrix_utils.py
@@ -329,17 +329,17 @@ class GaussianLVMParametrization:
     def latent_variable_labels(self) -> list[str]:
         return (
             ["$U_\\mathrm{all}$", "$U_X$", "$U_Y$"]
-            + [f"$Z_{i+1}$" for i in range(self.n_interacting)]
-            + [f"$E_{i+1}$" for i in range(self.dim_x)]
-            + [f"$F_{i+1}$" for i in range(self.dim_y)]
-            + [f"$V_{i+1}$" for i in range(self.n_interacting, self.dim_x)]
+            + [f"$Z_{i + 1}$" for i in range(self.n_interacting)]
+            + [f"$E_{i + 1}$" for i in range(self.dim_x)]
+            + [f"$F_{i + 1}$" for i in range(self.dim_y)]
+            + [f"$V_{i + 1}$" for i in range(self.n_interacting, self.dim_x)]
             + [f"$W_{i + 1}$" for i in range(self.n_interacting, self.dim_y)]
         )
 
     @property
     def xy_labels(self) -> list[str]:
-        return [f"$X_{i+1}$" for i in range(self.dim_x)] + [
-            f"$Y_{j+1}$" for j in range(self.dim_y)
+        return [f"$X_{i + 1}$" for i in range(self.dim_x)] + [
+            f"$Y_{j + 1}$" for j in range(self.dim_y)
         ]
 
 

--- a/tests/samplers/test_splitmultinormal.py
+++ b/tests/samplers/test_splitmultinormal.py
@@ -46,7 +46,7 @@ def test_symmetric_gaussian_mi(x: int, y: int, variance: float, n_samples: int =
     assert xy_sample.shape == (
         n_samples,
         x + y,
-    ), f"XxY sample shape: {xy_sample.shape} != {(n_samples, x+y)}"
+    ), f"XxY sample shape: {xy_sample.shape} != {(n_samples, x + y)}"
 
     assert np.allclose(
         mean, xy_sample.mean(axis=0), rtol=0.05, atol=0.07

--- a/tests/samplers/test_student_t.py
+++ b/tests/samplers/test_student_t.py
@@ -37,7 +37,7 @@ def test_samples_produced(x: int, y: int, n_samples: int, df: int, dispersion: f
     assert xy_sample.shape == (
         n_samples,
         x + y,
-    ), f"XxY sample shape: {xy_sample.shape} != {(n_samples, x+y)}"
+    ), f"XxY sample shape: {xy_sample.shape} != {(n_samples, x + y)}"
 
     assert np.allclose(
         mean, xy_sample.mean(axis=0), rtol=0.12, atol=0.07

--- a/workflows/benchmark/_common_benchmark_rules.smk
+++ b/workflows/benchmark/_common_benchmark_rules.smk
@@ -15,7 +15,7 @@ TASKS_DICT = {
 
 rule benchmark_tables:
     input: 'results.csv'
-    output: 'benchmark.html', 'benchmark_converged_only.html', 'benchmark_convergance.html'
+    output: 'benchmark.html', 'benchmark_converged_only.html', 'benchmark_convergence.html'
     run:
         results = utils.read_results(str(input))
         table = utils.create_benchmark_table(results, converged_only=False)
@@ -24,8 +24,8 @@ rule benchmark_tables:
         table = utils.create_benchmark_table(results, converged_only=True)
         table.to_html('benchmark_converged_only.html')
 
-        table = utils.create_convergance_table(results)
-        table.to_html('benchmark_convergance.html')
+        table = utils.create_convergence_table(results)
+        table.to_html('benchmark_convergence.html')
 
 
 # Gather all results into one CSV file

--- a/workflows/benchmark/_utils.py
+++ b/workflows/benchmark/_utils.py
@@ -117,7 +117,7 @@ def create_benchmark_table(results, n_samples=None, converged_only=False):
     return table_pretty
 
 
-def create_convergance_table(results, n_samples=None):
+def create_convergence_table(results, n_samples=None):
     if n_samples is None:
         n_samples = results["n_samples"].max()
 

--- a/workflows/benchmark/v2/config.py
+++ b/workflows/benchmark/v2/config.py
@@ -19,12 +19,10 @@ from bmi.benchmark.tasks.spiral import transform_spiral_task as spiralise
 # Note that each estimator implements `IMutualInformationPointEstimator` interface
 
 ESTIMATORS_DICT = {
-    "NWJ-10_5": estimators.NWJEstimator(verbose=False, hidden_layers=(10, 5)),
-    "MINE-10_5": estimators.MINEEstimator(verbose=False, hidden_layers=(10, 5)),
-    "InfoNCE-10_5": estimators.InfoNCEEstimator(verbose=False, hidden_layers=(10, 5)),
-    "Donsker-Varadhan-10_5": estimators.DonskerVaradhanEstimator(
-        verbose=False, hidden_layers=(10, 5)
-    ),
+    "NWJ": estimators.NWJEstimator(verbose=False),
+    "MINE": estimators.MINEEstimator(verbose=False),
+    "InfoNCE": estimators.InfoNCEEstimator(verbose=False),
+    "Donsker-Varadhan": estimators.DonskerVaradhanEstimator(verbose=False),
     "KSG-10": estimators.KSGEnsembleFirstEstimator(neighborhoods=(10,)),
     "CCA": estimators.CCAMutualInformationEstimator(),
 }

--- a/workflows/benchmark/v2/config.py
+++ b/workflows/benchmark/v2/config.py
@@ -20,11 +20,11 @@ from bmi.benchmark.tasks.spiral import transform_spiral_task as spiralise
 
 ESTIMATORS_DICT = {
     "NWJ-10_5": estimators.NWJEstimator(verbose=False, hidden_layers=(10, 5)),
-    # "MINE-10_5": estimators.MINEEstimator(verbose=False, hidden_layers=(10, 5)),
-    # "InfoNCE-10_5": estimators.InfoNCEEstimator(verbose=False, hidden_layers=(10, 5)),
-    # "Donsker-Varadhan-10_5": estimators.DonskerVaradhanEstimator(
-    #    verbose=False, hidden_layers=(10, 5)
-    # ),
+    "MINE-10_5": estimators.MINEEstimator(verbose=False, hidden_layers=(10, 5)),
+    "InfoNCE-10_5": estimators.InfoNCEEstimator(verbose=False, hidden_layers=(10, 5)),
+    "Donsker-Varadhan-10_5": estimators.DonskerVaradhanEstimator(
+        verbose=False, hidden_layers=(10, 5)
+    ),
     "KSG-10": estimators.KSGEnsembleFirstEstimator(neighborhoods=(10,)),
     "CCA": estimators.CCAMutualInformationEstimator(),
 }
@@ -97,4 +97,4 @@ N_SAMPLES: list[int] = [5_000]
 # === SEEDS ===
 # Seeds used for task sampling
 
-SEEDS: list[int] = list(range(3))  # TODO(frdrc): 10
+SEEDS: list[int] = list(range(10))

--- a/workflows/benchmark/v2/config.py
+++ b/workflows/benchmark/v2/config.py
@@ -1,0 +1,100 @@
+# ====================================
+# == Configuration of the benchmark ==
+# ====================================
+
+import bmi.benchmark.tasks.additive_noise as additive_noise
+import bmi.benchmark.tasks.bivariate_normal as binormal
+import bmi.benchmark.tasks.embeddings as embeddings
+import bmi.benchmark.tasks.mixtures as mixtures
+import bmi.benchmark.tasks.multinormal as multinormal
+import bmi.benchmark.tasks.student as student
+import bmi.estimators as estimators
+from bmi.benchmark.tasks import transform_rescale
+from bmi.benchmark.tasks.asinh import transform_asinh_task as asinh
+from bmi.benchmark.tasks.normal_cdf import transform_normal_cdf_task as normal_cdfise
+from bmi.benchmark.tasks.spiral import transform_spiral_task as spiralise
+
+# === ESTIMATORS ===
+# Defines the estimators to be run in the benchmark
+# Note that each estimator implements `IMutualInformationPointEstimator` interface
+
+ESTIMATORS_DICT = {
+    "NWJ-10_5": estimators.NWJEstimator(verbose=False, hidden_layers=(10, 5)),
+    # "MINE-10_5": estimators.MINEEstimator(verbose=False, hidden_layers=(10, 5)),
+    # "InfoNCE-10_5": estimators.InfoNCEEstimator(verbose=False, hidden_layers=(10, 5)),
+    # "Donsker-Varadhan-10_5": estimators.DonskerVaradhanEstimator(
+    #    verbose=False, hidden_layers=(10, 5)
+    # ),
+    "KSG-10": estimators.KSGEnsembleFirstEstimator(neighborhoods=(10,)),
+    "CCA": estimators.CCAMutualInformationEstimator(),
+}
+
+
+# === TASKS ===
+# Defines the benchmark tasks.
+# All tasks will be rescaled to the same range for numerical stability.
+
+TASK_MULTINORMAL_BIVAR_1x1 = binormal.task_bivariate_normal(gaussian_correlation=0.75)
+TASK_UNIFORM_FROM_BIVAR_1x1 = normal_cdfise(TASK_MULTINORMAL_BIVAR_1x1)
+
+TASK_MULTINORMAL_2PAIR_3x3 = multinormal.task_multinormal_2pair(3, 3)
+TASK_MULTINORMAL_2PAIR_5x5 = multinormal.task_multinormal_2pair(5, 5)
+
+
+UNSCALED_TASKS = (
+    # 1v1
+    additive_noise.task_additive_noise(epsilon=0.75),
+    asinh(student.task_student_identity(dim_x=1, dim_y=1, df=1)),
+    mixtures.task_x(),
+    mixtures.task_ai(),
+    # embedding
+    embeddings.transform_swissroll_task(TASK_UNIFORM_FROM_BIVAR_1x1, task_name="Swiss roll 2 × 1"),
+    # nv1
+    mixtures.task_waves(),
+    mixtures.task_galaxy(),
+    mixtures.task_concentric_multinormal(dim_x=3, n_components=5),
+    mixtures.task_concentric_multinormal(dim_x=5, n_components=5),
+    mixtures.task_concentric_multinormal(dim_x=3, n_components=10),  # *
+    mixtures.task_concentric_multinormal(dim_x=5, n_components=10),  # *
+    mixtures.task_concentric_multinormal(dim_x=25, n_components=5),  # *
+    # multinormal
+    multinormal.task_multinormal_dense(5, 5),
+    multinormal.task_multinormal_dense(25, 25),
+    multinormal.task_multinormal_dense(50, 50),
+    multinormal.task_multinormal_2pair(5, 5),
+    multinormal.task_multinormal_2pair(25, 25),
+    # inliers
+    mixtures.task_multinormal_sparse_w_inliers(dim_x=5, dim_y=5, inlier_fraction=0.2),
+    mixtures.task_multinormal_sparse_w_inliers(dim_x=25, dim_y=25, inlier_fraction=0.2),
+    mixtures.task_multinormal_sparse_w_inliers(dim_x=5, dim_y=5, inlier_fraction=0.5),  # *
+    mixtures.task_multinormal_sparse_w_inliers(dim_x=25, dim_y=25, inlier_fraction=0.5),  # *
+    # student
+    asinh(student.task_student_identity(dim_x=2, dim_y=2, df=1)),
+    asinh(student.task_student_identity(dim_x=3, dim_y=3, df=2)),
+    asinh(student.task_student_identity(dim_x=5, dim_y=5, df=2)),
+    # transformed
+    spiralise(TASK_MULTINORMAL_2PAIR_3x3),
+    spiralise(TASK_MULTINORMAL_2PAIR_5x5),
+)
+
+# Rescaled all tasks in case some estimator does not do it on its own
+TASKS = (
+    transform_rescale(
+        base_task=base_task,
+        task_name=base_task.name,
+        task_id=base_task.id,
+    )
+    for base_task in UNSCALED_TASKS
+)
+
+
+# === SAMPLES ===
+# Number of samples drawn from each task distribution
+
+N_SAMPLES: list[int] = [5_000]
+
+
+# === SEEDS ===
+# Seeds used for task sampling
+
+SEEDS: list[int] = list(range(3))  # TODO(frdrc): 10

--- a/workflows/benchmark/v2/run.smk
+++ b/workflows/benchmark/v2/run.smk
@@ -1,0 +1,13 @@
+# ==============================================
+# == Main workflow for running the benchmark. ==
+# ==============================================
+from config import ESTIMATORS_DICT, TASKS, N_SAMPLES, SEEDS
+
+workdir: "generated/benchmark/v2/"
+
+
+rule all:
+    input: 'results.csv', 'benchmark.html'
+
+
+include: "../_common_benchmark_rules.smk"

--- a/workflows/projects/Mixtures/v2_results_table.smk
+++ b/workflows/projects/Mixtures/v2_results_table.smk
@@ -1,0 +1,148 @@
+import numpy as np
+import pandas as pd
+import yaml
+
+
+def read_results(
+    path: str,
+    unpack_task_params: bool = True,
+    unpack_additional_information: bool = False,
+):
+    results = pd.read_csv(path)
+
+    # read dicts
+    for col in ["task_params", "additional_information"]:
+        results[col] = results[col].apply(lambda x: yaml.safe_load(x))
+
+    # unpack
+    rows = []
+    for _, row in results.iterrows():
+        row_dict = row.to_dict()
+
+        if unpack_task_params:
+            row_dict |= row_dict["task_params"]
+            del row_dict["task_params"]
+
+        if unpack_additional_information:
+            row_dict |= row_dict["additional_information"]
+            del row_dict["additional_information"]
+
+        rows.append(row_dict)
+
+    results = pd.DataFrame(rows)
+    return results
+
+
+
+def create_benchmark_table(results, n_samples):
+    if n_samples is None:
+        n_samples = results["n_samples"].max()
+
+    data = results[results["n_samples"] == n_samples]
+    data = results[["estimator_id", "task_id", "n_samples", "mi_estimate", "mi_true"]].copy()
+
+    # mean over seeds
+    data_mean = (
+        data.groupby(["estimator_id", "task_id"])["mi_estimate"]
+        .mean()
+        .reset_index()
+    )
+    data_std = (
+        data.groupby(["estimator_id", "task_id"])["mi_estimate"]
+        .std(ddof=1)
+        .reset_index()
+    )
+
+    data_mean["mean"] = data_mean["mi_estimate"]
+    data_std["std"] = data_std["mi_estimate"]
+
+    merged = pd.merge(data_mean, data_std, on=['estimator_id', 'task_id'])
+    merged["new_std"] = np.maximum(np.ceil(100 * merged["std"].values) / 100, 0.01)
+    
+    def format_output(row):
+        mean = row["mean"]
+        std = row["new_std"]
+        return f"${mean:.2f} \\pm {std:.2f}$"
+    
+    merged["output"] = merged.apply(format_output, axis=1)
+    merged = merged[["estimator_id", "task_id", "output"]]
+
+    # add "True MI" pseudo-estimator
+    task_id_mi_true = results[["task_id", "mi_true"]].drop_duplicates(subset=["task_id"])
+    def make_mi_true_nice(x: float) -> str:
+        y = f"{x:.2f}"
+        return "\\textbf{" + y + "}"
+    
+    data = pd.concat(
+        [
+            merged,
+            pd.DataFrame(
+                {
+                    "estimator_id": "True MI",
+                    "task_id": task_id_mi_true["task_id"],
+                    "output": task_id_mi_true['mi_true'].apply(make_mi_true_nice),
+                }
+            ),
+        ]
+    )
+
+    return data.pivot(index="task_id", columns="estimator_id", values="output")
+
+
+rule all:
+    input: "generated/projects/Mixtures/benchmark_table.txt"
+
+
+rule generate_table:
+    input: "generated/benchmark/v2/results.csv"
+    output: "generated/projects/Mixtures/benchmark_table.txt"
+    run:
+        input_df = read_results(str(input))
+        # Use 5,000 samples
+        output_df = create_benchmark_table(input_df, n_samples=5_000)
+
+        names = {
+            # one-dimensional
+            'asinh-student-identity-1-1-1': "Student (1-dim)",
+            '1v1-additive-0.75': "Additive",
+            '1v1-AI': "AI",
+            '1v1-X-0.9': "X",
+            'swissroll_x-normal_cdf-1v1-normal-0.75': "Swiss roll",
+
+            # m vs 1 dimension     
+            '2v1-galaxy-0.5-3.0': "Galaxy",
+            '2v1-waves-12-5.0-3.0': "Waves", 
+
+            '25v1-concentric_gaussians-5': "Concentric (25-dim, 5)",
+            '3v1-concentric_gaussians-10': "Concentric (3-dim, 10)",
+            '3v1-concentric_gaussians-5': "Concentric (3-dim, 5)", 
+            '5v1-concentric_gaussians-10': "Concentric (5-dim, 10)",
+            '5v1-concentric_gaussians-5': "Concentric (5-dim, 5)", 
+
+            # Multivariate normal
+            'multinormal-dense-5-5-0.5': "Normal (5-dim, dense)",
+            'multinormal-dense-25-25-0.5': "Normal (25-dim, dense)",
+            'multinormal-dense-50-50-0.5': "Normal (50-dim, dense)",
+            'multinormal-sparse-5-5-2-2.0': "Normal (5-dim, sparse)",
+            'multinormal-sparse-25-25-2-2.0': "Normal (25-dim, sparse)",
+
+            # Student
+            'asinh-student-identity-2-2-1': "Student (2-dim)",
+            'asinh-student-identity-3-3-2': "Student (3-dim)",
+            'asinh-student-identity-5-5-2': "Student (5-dim)", 
+
+            # Spiral
+            'spiral-multinormal-sparse-3-3-2-2.0': "Spiral (3-dim)",
+            'spiral-multinormal-sparse-5-5-2-2.0': "Spiral (5-dim)",
+
+            # Inliers
+            'mult-sparse-w-inliers-5-5-2-2.0-0.2': "Inliers (5-dim, 0.2)",
+            'mult-sparse-w-inliers-5-5-2-2.0-0.5': "Inliers (5-dim, 0.5)",
+            'mult-sparse-w-inliers-25-25-2-2.0-0.2': "Inliers (25-dim, 0.2)",
+            'mult-sparse-w-inliers-25-25-2-2.0-0.5': "Inliers (25-dim, 0.5)",
+        }
+
+        output_df.index = output_df.index.map(lambda x: names[x])
+
+        with open(str(output), "w") as fh:
+            fh.write(output_df.to_latex(escape=False))


### PR DESCRIPTION
Together with @pawel-czyz we've revisited our benchmark. 

Compared to benchmark `v1`:
  -  We've removed some less insightful tasks (leaving 13 tasks from the original benchmark).
  - Added 8 new tasks (+some experimental variations to determine the right task parameters) based on BMMs (Fine distributions).

At the same time, we made sure that mutual information in the `Task` and `FineSampler` classes is evaluated in a lazy manner, so that there is no overhead from Monte Carlo sampling at the task declaration stage.

## Additional information
This PR is required for #154 .