### PR TITLE
Rename fine distributions to BMMs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12"]
+        # Use only 3.11 as for 3.12 pytype is not supported yet
+        python-version: ["3.11"]
         poetry-version: ["1.3.2"]
 
     steps:

--- a/docs/api/bmm.md
+++ b/docs/api/bmm.md
@@ -1,4 +1,4 @@
-# Fine distributions
+# Bend and Mix Models
 
 ## Core utilities
 
@@ -12,7 +12,7 @@
 
 ::: bmi.samplers._tfp.ProductDistribution
 
-::: bmi.samplers._tfp.FineSampler
+::: bmi.samplers._tfp.BMMSampler
 
 ## Basic distributions
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,8 +12,8 @@
 
 [Samplers](samplers.md) represent joint probability distributions with known mutual information from which one can sample. They are lower level than `Tasks` and can be used to define new tasks by transformations which preserve mutual information.
 
-### Fine distributions
-[Subpackage](fine-distributions.md) implementing distributions in which the ground-truth mutual information may not be known analytically, but can be efficiently approximated using Monte Carlo methods. 
+### Bend and Mix Models
+[Subpackage](bmm.md) implementing distributions known as *Bend and Mix Models*, for which the ground-truth mutual information may not be known analytically, but can be efficiently approximated using Monte Carlo methods. 
 
 ## Interfaces
 [Interfaces](interfaces.md) defines the main interfaces used in the package.

--- a/docs/api/samplers.md
+++ b/docs/api/samplers.md
@@ -26,9 +26,9 @@ Samplers represent probability distributions with known mutual information.
 
 ::: bmi.samplers.ZeroInflatedPoissonizationSampler
 
-## Fine distributions
+## Bend and Mix Models
 
-See the [fine distributions subpackage API](fine-distributions.md) for more information.
+See the [Bend and Mix Models subpackage API](bmm.md) for more information.
 
 ### Auxiliary
 

--- a/docs/bmm.md
+++ b/docs/bmm.md
@@ -1,32 +1,32 @@
-# Fine distributions
+# Bend and Mix Models
 
-In this tutorial we will take a closer look at the family of *fine distributions*, proposed in [The Mixtures and the Neural Critics](https://arxiv.org/abs/2310.10240) paper[@mixtures-neural-critics-2023].
+In this tutorial we will take a closer look at the family of *Bend and Mix Models (BMMs)*, proposed in [*On the properties and estimation of pointwise mutual information profiles*](https://arxiv.org/abs/2310.10240) manuscript.
 
-A distribution $P_{XY}$ is fine, if it is possible to evaluate the densities $\log p_{XY}(x, y)$, $\log p_X(x)$, and $\log p_Y(y)$ for arbitrary points and to efficiently generate samples from $P_{XY}$.
+A distribution $P_{XY}$ is a BMM, if it is possible to evaluate the densities $\log p_{XY}(x, y)$, $\log p_X(x)$, and $\log p_Y(y)$ for arbitrary points and to efficiently generate samples from $P_{XY}$.
 In particular, one can evaluate [pointwise mutual information](https://en.wikipedia.org/wiki/Pointwise_mutual_information) 
 
 $\mathrm{PMI}(x, y) = \log \frac{p_{XY}(x, y)}{p_X(x)p_Y(y)}$
 
 and use a Monte Carlo approximation of the mutual information $I(X; Y) = \mathbb E_{(x, y)\sim P_{XY}}[\mathrm{PMI}(x, y)]$.
 
-The fine distribution can therefore be implemented as a triple of [TensorFlow Probability on JAX](https://www.tensorflow.org/probability/examples/TensorFlow_Probability_on_JAX) distributions: the joint distribution $P_{XY}$ and marginals $P_X$ and $P_Y$.
+A BMM can therefore be implemented as a triple of [TensorFlow Probability on JAX](https://www.tensorflow.org/probability/examples/TensorFlow_Probability_on_JAX) distributions: the joint distribution $P_{XY}$ and marginals $P_X$ and $P_Y$.
 
 For example, let's create a multivariate normal distribution:
 
 ```python
 import jax.numpy as jnp
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 # Define a fine distribution
 cov = jnp.asarray([[1., 0.8], [0.8, 1.]])
-dist = fine.MultivariateNormalDistribution(dim_x=1, dim_y=1, covariance=cov)
+dist = bmm.MultivariateNormalDistribution(dim_x=1, dim_y=1, covariance=cov)
 ```
 
-To see how fine distributions can be used in the benchmark, see [this section](#connecting-fine-distributions-and-samplers).
+To see how fine distributions can be used in the benchmark, see [this section](#connecting-bmms-and-samplers).
 
-## Basic operations supported by fine distributions
+## Basic operations supported by BMMs
 
-A fine distribution $P_{XY}$ can be used to sample from $P_{XY}$ or evaluate the pointwise mutual information $\mathrm{PMI}(x, y)$ at any point.
+A BMM $P_{XY}$ can be used to sample from $P_{XY}$ or evaluate the pointwise mutual information $\mathrm{PMI}(x, y)$ at any point.
 The distribution of $\mathrm{PMI}(x, y)$, where $(x, y)\sim P_{XY}$ is called the *PMI profile* and can be approximated via the histograms from the samples.
 Similarly, sample-based Monte Carlo approximation can be used to estimate the mutual information $I(X; Y)$, which is the mean of the PMI profile.
 
@@ -34,11 +34,11 @@ Similarly, sample-based Monte Carlo approximation can be used to estimate the mu
 import jax.numpy as jnp
 from jax import random
 
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
-# Define a fine distribution:
+# Define a Bend and Mix model:
 cov = jnp.asarray([[1., 0.8], [0.8, 1.]])
-dist = fine.MultivariateNormalDistribution(dim_x=1, dim_y=1, covariance=cov)
+dist = bmm.MultivariateNormalDistribution(dim_x=1, dim_y=1, covariance=cov)
 
 # Sample 100_000 points from the distribution:
 key = random.PRNGKey(42)
@@ -64,53 +64,54 @@ print(mi_estimate)  # 0.51192063
 print(mi_mcse)  # 0.00252177
 ```
 
-### Combining and transforming fine distributions
+### Combining and transforming BMMs
 
-One can construct new fine distributions from the existing ones by two basic operations: transformation by a diffeomorphism and constructing a mixture.
+One can construct new Bend and Mix Models from the existing ones by two basic operations: bending (transforming with a diffeomorphism) or constructing a mixture of given BMMs.
 
 #### Transformation by a diffeomorphism 
 
-A fine distribution $P_{XY}$ can be transformed by a diffeomorphism of the form $f\times g$ to obtain a new fine distribution $P_{f(X)g(Y)}$.
+A BMM $P_{XY}$ can be bent, i.e. transformed by a diffeomorphism of the form $f\times g$ to obtain a new fine distribution $P_{f(X)g(Y)}$.
 Any diffeomorphism supported by [TensorFlow Probability on JAX](https://www.tensorflow.org/probability/examples/TensorFlow_Probability_on_JAX#bijectors) can be used.
 
 ```python
 import jax.numpy as jnp
 from tensorflow_probability.substrates import jax as tfp
 
-from bmi.samplers import fine, SparseLVMParametrization
+from bmi.samplers import bmm, SparseLVMParametrization
 
 # Define a normal distribution
 cov = SparseLVMParametrization(dim_x=2, dim_y=3, n_interacting=1).covariance
-normal = fine.MultivariateNormalDistribution(dim_x=2, dim_y=3, covariance=cov)
+normal = bmm.MultivariateNormalDistribution(dim_x=2, dim_y=3, covariance=cov)
 
 # Use a TensorFlow Probability bijector to transform the distribution
-transformed_normal = fine.transform(dist=normal, x_transform=tfp.bijectors.Sigmoid(), y_transform=tfp.bijectors.Sigmoid())
+transformed_normal = bmm.transform(dist=normal, x_transform=tfp.bijectors.Sigmoid(), y_transform=tfp.bijectors.Sigmoid())
 ```
 
-Note that samplers can be transformed by arbitrary continuous injective functions, not only diffeomorphisms, which preserve mutual information. However, this comes at the cost of losing the ability to compute pointwise mutual information. To wrap a fine distribution into a sampler, see [this section](#connecting-fine-distributions-and-samplers).
+Note that samplers can be transformed by arbitrary continuous injective functions, not only diffeomorphisms, which preserve mutual information. However, this comes at the cost of losing the ability to compute pointwise mutual information. To wrap a fine distribution into a sampler, see [this section](#connecting-bmms-and-samplers).
 
 #### Constructing a mixture
 
-If $P_{X_1Y_1}, \dotsc, P_{X_KY_K}$ are arbitrary fine distributions defined on the same space $\mathcal X\times \mathcal Y$, and $w_1, \dotsc, w_K$ are positive numbers such that $w_1 + \dotsc + w_K=1$, then the mixture
+If $P_{X_1Y_1}, \dotsc, P_{X_KY_K}$ are arbitrary BMMs defined on the same space $\mathcal X\times \mathcal Y$, and $w_1, \dotsc, w_K$ are positive numbers such that $w_1 + \dotsc + w_K=1$, then the mixture
 
 $$P_{XY} = \sum_{k=1}^K w_k P_{X_kY_K}$$
 
-is also a fine distribution. Note that even if the component distributions do not encode any information ($I(X_k; Y_k) = 0$), the mixture $P_{XY}$ can have $I(X; Y) > 0$ and be as large as $\log K$.
+is also a BMM.
+Note that even if the component distributions do not encode any information ($I(X_k; Y_k) = 0$), the mixture $P_{XY}$ can have $I(X; Y) > 0$ and be as large as $\log K$.
 
 ```python
 import jax.numpy as jnp
 from tensorflow_probability.substrates import jax as tfp
 
-from bmi.samplers import fine, SparseLVMParametrization
+from bmi.samplers import bmm, SparseLVMParametrization
 
 # Define a normal distribution
 cov1 = SparseLVMParametrization(dim_x=2, dim_y=3, n_interacting=1).covariance
-normal1 = fine.MultivariateNormalDistribution(dim_x=2, dim_y=3, covariance=cov1)
+normal1 = bmm.MultivariateNormalDistribution(dim_x=2, dim_y=3, covariance=cov1)
 
 cov2 = SparseLVMParametrization(dim_x=2, dim_y=3, n_interacting=2).covariance
-normal2 = fine.MultivariateNormalDistribution(dim_x=2, dim_y=3, covariance=cov2)
+normal2 = bmm.MultivariateNormalDistribution(dim_x=2, dim_y=3, covariance=cov2)
 
-mixture = fine.mixture(proportions=[0.8, 0.2], components=[normal1, normal2])
+mixture = bmm.mixture(proportions=[0.8, 0.2], components=[normal1, normal2])
 ```
 
 ## Discrete variables
@@ -126,7 +127,7 @@ Below we will show an example:
 ```python
 import jax.numpy as jnp
 
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 from tensorflow_probability.substrates import jax as tfp
 tfd = tfp.distributions
@@ -142,9 +143,9 @@ def construct_bernoulli(p: float, dtype=jnp.float64) -> tfd.Distribution:
 
 
 # Define the distributions X_k. Each of them is a continuous distribution on R^2.
-x1 = fine.construct_multivariate_student_distribution(mean=-jnp.ones(2), dispersion=0.2 * jnp.eye(2), df=8)
-x2 = fine.construct_multivariate_normal_distribution(mean=jnp.zeros(2), covariance=jnp.asarray([[1.0, 0.8], [0.8, 1.0]]))
-x3 = fine.construct_multivariate_student_distribution(mean=jnp.ones(2), dispersion=0.2 * jnp.eye(2), df=5)
+x1 = bmm.construct_multivariate_student_distribution(mean=-jnp.ones(2), dispersion=0.2 * jnp.eye(2), df=8)
+x2 = bmmm.construct_multivariate_normal_distribution(mean=jnp.zeros(2), covariance=jnp.asarray([[1.0, 0.8], [0.8, 1.0]]))
+x3 = bmm.construct_multivariate_student_distribution(mean=jnp.ones(2), dispersion=0.2 * jnp.eye(2), df=5)
 
 # Define the distributions for Y_k. Each of them is a discrete distribution over the alphabet {0, 1}.
 y1 = construct_bernoulli(0.95)
@@ -152,40 +153,41 @@ y2 = construct_bernoulli(0.5)
 y3 = construct_bernoulli(0.05)
 
 # Define the product distributions P(X_k, Y_k).
-components = [fine.ProductDistribution(dist_x, dist_y) for dist_x, dist_y in zip([x1, x2, x3], [y1, y2, y3])]
+components = [bmm.ProductDistribution(dist_x, dist_y) for dist_x, dist_y in zip([x1, x2, x3], [y1, y2, y3])]
 
 # Construct the distribution P(X, Y) distribution.
-# As this is a fine distribution, one can construct the PMI profile, approximate MI, etc.
-joint_distribution = fine.mixture(proportions=[0.25, 0.5, 0.25], components=components)
+# As this is a BMM, one can construct the PMI profile, approximate MI, etc.
+joint_distribution = bmm.mixture(proportions=[0.25, 0.5, 0.25], components=components)
 ```
 
-## Connecting fine distributions and samplers 
-One of the main abstractions of the proposed package is the [`ISampler`](api/interfaces.md#bmi.interface.ISampler) class, which holds a joint probability distribution with known mutual information. As such, samplers can be [transformed with arbitrary continuous injective functions](api/samplers.md#bmi.samplers.TransformedSampler), [combined with other samplers](api/samplers.md#bmi.samplers.IndependentConcatenationSampler) or used to [define named benchmark tasks](api/tasks.md).
+## Connecting BMMs and samplers 
+One of the main abstractions of the proposed package is the [`ISampler`](api/interfaces.md#bmi.interface.ISampler) class, which holds a joint probability distribution with known mutual information.
+As such, samplers can be [transformed with arbitrary continuous injective functions](api/samplers.md#bmi.samplers.TransformedSampler), [combined with other samplers](api/samplers.md#bmi.samplers.IndependentConcatenationSampler) or used to [define named benchmark tasks](api/tasks.md).
 
-Fine distributions can be used to create samplers using the [`FineSampler`](api/fine-distributions.md#bmi.samplers._tfp.FineSampler) wrapper. For example, let's create a sampler for a bivariate normal distribution:
+Fine distributions can be used to create samplers using the [`BMMSampler`](api/bmm.md#bmi.samplers._tfp.BMMSampler) wrapper. For example, let's create a sampler for a bivariate normal distribution:
 
 ```python
 import jax.numpy as jnp
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
-# Define a fine distribution
+# Define a BMM
 cov = jnp.asarray([[1.0, 0.8], [0.8, 1.0]])
-dist = fine.MultivariateNormalDistribution(dim_x=1, dim_y=1, covariance=cov)
+dist = bmm.MultivariateNormalDistribution(dim_x=1, dim_y=1, covariance=cov)
 
 # Wrap the distribution into a sampler.
 # We will use 10 000 samples to estimate ground-truth mutual information.
 # Generally, the more samples, the better.
-sampler = fine.FineSampler(dist, mi_estimate_sample=10_000, mi_estimate_seed=42)
+sampler = bmm.FineSampler(dist, mi_estimate_sample=10_000, mi_estimate_seed=42)
 
 print(sampler.mutual_information())  # 0.5178049
 # Created sampler can be used as usual (transformed, used to create tasks, combined, etc.)
 ```
 
-## Estimating mutual information with fine distributions
+## Estimating mutual information with BMMs
 
-Consider a parametric family of fine distributions $\{P_\theta \mid \theta \in \mathcal T\}$, where $P_{\theta}$ is a model for a joint distribution $P(X, Y\mid \theta)$.
+Consider a parametric family of BMMs, $\{P_\theta \mid \theta \in \mathcal T\}$, where $P_{\theta}$ is a model for a joint distribution $P(X, Y\mid \theta)$.
 For example, if $X$ and $Y$ are assumed to be jointly multivariate norrmal, each $P_\theta$ will be a multivariate norrmal distribution with $\theta$ representing the mean vector and covariance matrix.
-As each $P_\theta$ is fine, one can calculate the mutual information between the idealised variables $X$ and $Y$ for different parameters $\theta$.
+As each $P_\theta$ is a BMM, one can calculate the mutual information between the idealised variables $X$ and $Y$ for different parameters $\theta$.
 
 Hence, once a data set $(x_1, y_1), \dotsc, (x_N, y_N)$ is available, one can construct the Bayesian posterior on the parameters $P(\theta \mid (x_1, y_1),\dotsc, (x_N, y_N))$ and use it to obtain the posterior distribution on $I(X; Y)$.
 
@@ -197,21 +199,19 @@ Hence, the workflow for model-based estimation of mutual information is as follo
 2. Ensure that for each parameter $\theta$, you can construct the distribution $P_\theta$ (e.g., by implementing a simple wrapper).
 3. Use the data set to construct the posterior distribution $P(\theta \mid (x_1, y_1),\dotsc, (x_N, y_N))$.
 4. Ensure that the model is well-specified and does not underfit or overfit the data.
-5. Wrap the samples from the posterior in the fine distributions and use Monte Carlo approximation to estimate the mutual information to obtain the samples from the mutual information posterior.
+5. Wrap the samples from the posterior in BMMs and use Monte Carlo approximation to estimate the mutual information to obtain the samples from the mutual information posterior.
 
 As an example using NumPyro to fit a mixture of multivariate normal distributions, see [`workflows/Mixtures/fitting_gmm.smk`](https://github.com/cbg-ethz/bmi/blob/main/workflows/Mixtures/fitting_gmm.smk).
 
 ## FAQ
 
 ### Where is the API?
-The API is [here](api/fine-distributions.md).
+The API is [here](api/bmm.md).
 
 ### What is the difference between a fine distribution and a sampler?
-Samplers are more general than fine distributions. [This section](#connecting-fine-distributions-and-samplers) explains how to wrap a fine distribution into a sampler.
+Samplers are more general than fine distributions. [This section](#connecting-bmms-and-samplers) explains how to wrap a fine distribution into a sampler.
 
 ### How should I choose the number of samples for the mutual information estimation?
 If variance of the PMI profile is finite and equal to $V$, then the Monte Carlo Standard Error (MCSE) of the mutual information estimate is equal to $\sqrt{V/n}$.
 We suggest to obtain an estimate for e.g., 10,000 samples (which should be fast) and observing whether the MCSE is small enough.
 Additionally, we suggest to repeat sampling several times and observing whether the MCSE is stable: it may be possible that for some problems the variance of the PMI profile may be infinite and MCSE is not a valid uncertainty estimate.
-
-\bibliography

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,7 @@ nav:
   - Home: index.md
   - Estimators: estimators.md
   - Benchmark: benchmarking-new-estimator.md
-  - Fine distributions: fine-distributions.md
+  - Bend and Mix Models: bmm.md
   - Contributing: contributing.md
   - API: api/index.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ scipy = "^1.10.1"
 tqdm = "^4.64.1"
 tensorflow-probability = {extras = ["jax"], version = "^0.20.1"}
 
+[tool.poetry.group.bayes]
+optional = true
+
+[tool.poetry.group.bayes.dependencies]
+numpyro = "^0.14.0"
 
 [tool.poetry.group.dev]
 optional = true

--- a/references.bib
+++ b/references.bib
@@ -1,10 +1,11 @@
-@misc{mixtures-neural-critics-2023,
-      title={The Mixtures and the Neural Critics: On the Pointwise Mutual Information Profiles of Fine Distributions}, 
+@misc{pmi-profiles-bmms-2023,
+      title={On the Properties and Estimation of Pointwise Mutual Information Profiles}, 
       author={Paweł Czyż and Frederic Grabowski and Julia E. Vogt and Niko Beerenwinkel and Alexander Marx},
       year={2023},
       eprint={2310.10240},
       archivePrefix={arXiv},
-      primaryClass={stat.ML}
+      primaryClass={stat.ML},
+      url={https://arxiv.org/abs/2310.10240}
 }
 
 @inproceedings{beyond-normal-2023,

--- a/src/bmi/benchmark/tasks/mixtures.py
+++ b/src/bmi/benchmark/tasks/mixtures.py
@@ -27,7 +27,7 @@ def task_x(
             for x in [-1, 1]
         ],
     )
-    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.BMMSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     return Task(
         sampler=sampler,
@@ -94,7 +94,7 @@ def task_ai(
             ),
         ],
     )
-    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.BMMSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     return Task(
         sampler=sampler,
@@ -123,7 +123,7 @@ def task_galaxy(
         ],
     )
 
-    base_sampler = bmm.FineSampler(balls_mixt, mi_estimate_sample=mi_estimate_sample)
+    base_sampler = bmm.BMMSampler(balls_mixt, mi_estimate_sample=mi_estimate_sample)
     a = jnp.array([[0, -1], [1, 0]])
     spiral = transforms.Spiral(a, speed=speed)
 
@@ -162,7 +162,7 @@ def task_waves(
             for x in range(n_components)
         ],
     )
-    base_sampler = bmm.FineSampler(base_dist, mi_estimate_sample=mi_estimate_sample)
+    base_sampler = bmm.BMMSampler(base_dist, mi_estimate_sample=mi_estimate_sample)
     aux_sampler = samplers.TransformedSampler(
         base_sampler,
         transform_x=lambda x: x
@@ -205,7 +205,7 @@ def task_concentric_multinormal(
             for i in range(1, 1 + n_components)
         ],
     )
-    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.BMMSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     return Task(
         sampler=sampler,
@@ -254,7 +254,7 @@ def task_multinormal_sparse_w_inliers(
         components=[signal_dist, noise_dist],
     )
 
-    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.BMMSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     task_id = f"mult-sparse-w-inliers-{dim_x}-{dim_y}-{n_interacting}-{strength}-{inlier_fraction}"
     return Task(

--- a/src/bmi/benchmark/tasks/mixtures.py
+++ b/src/bmi/benchmark/tasks/mixtures.py
@@ -4,7 +4,7 @@ import numpy as np
 import bmi.samplers as samplers
 import bmi.transforms as transforms
 from bmi.benchmark.task import Task
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 _MC_MI_ESTIMATE_SAMPLE = 100_000
 
@@ -15,10 +15,10 @@ def task_x(
 ) -> Task:
     """The X distribution."""
 
-    dist = fine.mixture(
+    dist = bmm.mixture(
         proportions=jnp.array([0.5, 0.5]),
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=samplers.canonical_correlation([x * gaussian_correlation]),
                 mean=jnp.zeros(2),
                 dim_x=1,
@@ -27,7 +27,7 @@ def task_x(
             for x in [-1, 1]
         ],
     )
-    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     return Task(
         sampler=sampler,
@@ -47,36 +47,36 @@ def task_ai(
     corr = 0.95
     var_x = 0.04
 
-    dist = fine.mixture(
+    dist = bmm.mixture(
         proportions=jnp.full(6, fill_value=1 / 6),
         components=[
             # I components
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([1.0, 0.0]),
                 covariance=np.diag([0.01, 0.2]),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([1.0, 1]),
                 covariance=np.diag([0.05, 0.001]),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([1.0, -1]),
                 covariance=np.diag([0.05, 0.001]),
             ),
             # A components
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([-0.8, -0.2]),
                 covariance=np.diag([0.03, 0.001]),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([-1.2, 0.0]),
@@ -84,7 +84,7 @@ def task_ai(
                     [[var_x, jnp.sqrt(var_x * 0.2) * corr], [jnp.sqrt(var_x * 0.2) * corr, 0.2]]
                 ),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([-0.4, 0.0]),
@@ -94,7 +94,7 @@ def task_ai(
             ),
         ],
     )
-    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     return Task(
         sampler=sampler,
@@ -110,10 +110,10 @@ def task_galaxy(
 ) -> Task:
     """The Galaxy distribution."""
 
-    balls_mixt = fine.mixture(
+    balls_mixt = bmm.mixture(
         proportions=jnp.array([0.5, 0.5]),
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=samplers.canonical_correlation([0.0], additional_y=1),
                 mean=jnp.array([x, x, x]) * distance / 2,
                 dim_x=2,
@@ -123,7 +123,7 @@ def task_galaxy(
         ],
     )
 
-    base_sampler = fine.FineSampler(balls_mixt, mi_estimate_sample=mi_estimate_sample)
+    base_sampler = bmm.FineSampler(balls_mixt, mi_estimate_sample=mi_estimate_sample)
     a = jnp.array([[0, -1], [1, 0]])
     spiral = transforms.Spiral(a, speed=speed)
 
@@ -150,10 +150,10 @@ def task_waves(
 
     assert n_components > 0
 
-    base_dist = fine.mixture(
+    base_dist = bmm.mixture(
         proportions=jnp.ones(n_components) / n_components,
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=jnp.diag(jnp.array([0.1, 1.0, 0.1])),
                 mean=jnp.array([x, 0, x % 4]) * 1.5,
                 dim_x=2,
@@ -162,7 +162,7 @@ def task_waves(
             for x in range(n_components)
         ],
     )
-    base_sampler = fine.FineSampler(base_dist, mi_estimate_sample=mi_estimate_sample)
+    base_sampler = bmm.FineSampler(base_dist, mi_estimate_sample=mi_estimate_sample)
     aux_sampler = samplers.TransformedSampler(
         base_sampler,
         transform_x=lambda x: x
@@ -193,10 +193,10 @@ def task_concentric_multinormal(
 
     assert n_components > 0
 
-    dist = fine.mixture(
+    dist = bmm.mixture(
         proportions=jnp.ones(n_components) / n_components,
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=jnp.diag(jnp.array(dim_x * [i**2] + [0.0001])),
                 mean=jnp.array(dim_x * [0.0] + [1.0 * i]),
                 dim_x=dim_x,
@@ -205,7 +205,7 @@ def task_concentric_multinormal(
             for i in range(1, 1 + n_components)
         ],
     )
-    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     return Task(
         sampler=sampler,
@@ -238,23 +238,23 @@ def task_multinormal_sparse_w_inliers(
         eta_x=strength,
     )
 
-    signal_dist = fine.MultivariateNormalDistribution(
+    signal_dist = bmm.MultivariateNormalDistribution(
         dim_x=dim_x,
         dim_y=dim_y,
         covariance=params.correlation,
     )
 
-    noise_dist = fine.ProductDistribution(
+    noise_dist = bmm.ProductDistribution(
         dist_x=signal_dist.dist_x,
         dist_y=signal_dist.dist_y,
     )
 
-    dist = fine.mixture(
+    dist = bmm.mixture(
         proportions=jnp.array([1 - inlier_fraction, inlier_fraction]),
         components=[signal_dist, noise_dist],
     )
 
-    sampler = fine.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
+    sampler = bmm.FineSampler(dist, mi_estimate_sample=mi_estimate_sample)
 
     task_id = f"mult-sparse-w-inliers-{dim_x}-{dim_y}-{n_interacting}-{strength}-{inlier_fraction}"
     return Task(

--- a/src/bmi/samplers/__init__.py
+++ b/src/bmi/samplers/__init__.py
@@ -13,7 +13,7 @@ from bmi.samplers._matrix_utils import (
 )
 
 # isort: on
-import bmi.samplers._tfp as fine
+import bmi.samplers._tfp as bmm
 from bmi.samplers._independent_coordinates import IndependentConcatenationSampler
 from bmi.samplers._split_student_t import SplitStudentT
 from bmi.samplers._splitmultinormal import BivariateNormalSampler, SplitMultinormal
@@ -33,7 +33,7 @@ __all__ = [
     "AdditiveUniformSampler",
     "BaseSampler",
     "canonical_correlation",
-    "fine",
+    "bmm",
     "parametrised_correlation_matrix",
     "BivariateNormalSampler",
     "SplitMultinormal",

--- a/src/bmi/samplers/_tfp/__init__.py
+++ b/src/bmi/samplers/_tfp/__init__.py
@@ -19,7 +19,7 @@ from bmi.samplers._tfp._student import (
 
 # isort: on
 from bmi.samplers._tfp._product import ProductDistribution
-from bmi.samplers._tfp._wrapper import FineSampler
+from bmi.samplers._tfp._wrapper import BMMSampler
 
 __all__ = [
     "JointDistribution",
@@ -30,7 +30,7 @@ __all__ = [
     "MultivariateNormalDistribution",
     "MultivariateStudentDistribution",
     "ProductDistribution",
-    "FineSampler",
+    "BMMSampler",
     "construct_multivariate_normal_distribution",
     "construct_multivariate_student_distribution",
 ]

--- a/src/bmi/samplers/_tfp/_core.py
+++ b/src/bmi/samplers/_tfp/_core.py
@@ -11,9 +11,10 @@ tfb = tfp.bijectors
 
 @dataclasses.dataclass
 class JointDistribution:
-    """The main object of this package.
-    Represents a joint distribution $P_{XY}$ together
-    with the marginal distributions $P_X$ and $P_Y$.
+    """The main object of this package, representing
+    a Bend and Mix Model (BMM), i.e., a joint distribution
+    $P_{XY}$ together with the marginal distributions
+    $P_X$ and $P_Y$.
 
     Attributes:
         dist: $P_{XY}$

--- a/src/bmi/samplers/_tfp/_wrapper.py
+++ b/src/bmi/samplers/_tfp/_wrapper.py
@@ -9,7 +9,7 @@ from bmi.samplers.base import BaseSampler, KeyArray, cast_to_rng
 
 
 class FineSampler(BaseSampler):
-    """Wraps a given fine distribution into a sampler."""
+    """Wraps a given Bend and Mix Model (BMM) into a sampler."""
 
     def __init__(
         self,
@@ -21,8 +21,8 @@ class FineSampler(BaseSampler):
         """
 
         Args:
-            dist: fine distribution to be wrapped
-            mi: mutual information of the fine distribution, if already calculated.
+            dist: distribution represented by a BMM to be wrapped
+            mi: mutual information of the distribution, if already calculated.
                 If not provided, it will be estimated via Monte Carlo sampling.
             mi_estimate_seed: seed for the Monte Carlo sampling
             mi_estimate_sample: number of samples for the Monte Carlo sampling

--- a/src/bmi/samplers/_tfp/_wrapper.py
+++ b/src/bmi/samplers/_tfp/_wrapper.py
@@ -8,7 +8,7 @@ from bmi.samplers._tfp._core import JointDistribution, monte_carlo_mi_estimate
 from bmi.samplers.base import BaseSampler, KeyArray, cast_to_rng
 
 
-class FineSampler(BaseSampler):
+class BMMSampler(BaseSampler):
     """Wraps a given Bend and Mix Model (BMM) into a sampler."""
 
     def __init__(

--- a/tests/samplers/tfp/test_product.py
+++ b/tests/samplers/tfp/test_product.py
@@ -3,20 +3,20 @@ import jax.numpy as jnp
 import pytest
 
 import bmi.samplers
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 
 def test_product_distribution(dim_x: int = 2, dim_y: int = 3, n_points: int = 10) -> None:
     assert dim_y >= dim_x, "We construct canonical correlation matrix, so we want this constraint."
 
-    dist_dependent = fine.MultivariateNormalDistribution(
+    dist_dependent = bmm.MultivariateNormalDistribution(
         dim_x=dim_x,
         dim_y=dim_y,
         covariance=bmi.samplers.canonical_correlation(
             jnp.full((dim_x,), fill_value=0.5), additional_y=dim_y - dim_x
         ),
     )
-    dist_independent = fine.ProductDistribution(
+    dist_independent = bmm.ProductDistribution(
         dist_x=dist_dependent.dist_x, dist_y=dist_dependent.dist_y
     )
 

--- a/tests/samplers/tfp/test_wrapper.py
+++ b/tests/samplers/tfp/test_wrapper.py
@@ -10,7 +10,7 @@ def test_can_create_sampler() -> None:
     )
     mi = -0.5 * jnp.log(1 - 0.5**2)
 
-    sampler = bmm.FineSampler(dist=dist, mi_estimate_seed=0, mi_estimate_sample=1_000)
+    sampler = bmm.BMMSampler(dist=dist, mi_estimate_seed=0, mi_estimate_sample=1_000)
 
     x_sample, y_sample = sampler.sample(n_points=10, rng=0)
     assert x_sample.shape == (10, 1)

--- a/tests/samplers/tfp/test_wrapper.py
+++ b/tests/samplers/tfp/test_wrapper.py
@@ -1,16 +1,16 @@
 import jax.numpy as jnp
 import pytest
 
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 
 def test_can_create_sampler() -> None:
-    dist = fine.MultivariateNormalDistribution(
+    dist = bmm.MultivariateNormalDistribution(
         dim_x=1, dim_y=1, covariance=jnp.asarray([[1, 0.5], [0.5, 1]])
     )
     mi = -0.5 * jnp.log(1 - 0.5**2)
 
-    sampler = fine.FineSampler(dist=dist, mi_estimate_seed=0, mi_estimate_sample=1_000)
+    sampler = bmm.FineSampler(dist=dist, mi_estimate_seed=0, mi_estimate_sample=1_000)
 
     x_sample, y_sample = sampler.sample(n_points=10, rng=0)
     assert x_sample.shape == (10, 1)

--- a/workflows/projects/Mixtures/cool_tasks.smk
+++ b/workflows/projects/Mixtures/cool_tasks.smk
@@ -1,4 +1,4 @@
-"""Demonstration of the capabilities of the fine distribution family."""
+"""Demonstration of the capabilities of the BMM family."""
 import numpy as np
 import pandas as pd
 import matplotlib
@@ -8,7 +8,7 @@ matplotlib.use("agg")
 import jax.numpy as jnp
 
 import bmi
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 import example_distributions as ed
 
@@ -131,7 +131,7 @@ rule plot_pmi_profiles:
         for dist, task_name, ax in zip(dists, tasks_official, axs):
             import jax
             key = jax.random.PRNGKey(1024)
-            pmi_values = fine.pmi_profile(key=key, dist=dist, n=100_000)
+            pmi_values = bmm.pmi_profile(key=key, dist=dist, n=100_000)
             bins = np.linspace(-5, 5, 101)
             ax.hist(pmi_values, bins=bins, density=True, alpha=0.5)
             ax.set_xlabel(task_name)

--- a/workflows/projects/Mixtures/example_distributions.py
+++ b/workflows/projects/Mixtures/example_distributions.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 
 import bmi
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 
 @dataclasses.dataclass
@@ -20,16 +20,16 @@ class ExampleDistribution:
     It is used for PMI profile estimation.
     """
 
-    dist: fine.JointDistribution
+    dist: bmm.JointDistribution
     sampler: bmi.ISampler
 
 
 def create_x_distribution(_sample: int = 100) -> ExampleDistribution:
     """The X distribution"""
-    x_dist = fine.mixture(
+    x_dist = bmm.mixture(
         proportions=jnp.array([0.5, 0.5]),
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=0.3 * bmi.samplers.canonical_correlation([x * 0.9]),
                 mean=jnp.zeros(2),
                 dim_x=1,
@@ -38,16 +38,16 @@ def create_x_distribution(_sample: int = 100) -> ExampleDistribution:
             for x in [-1, 1]
         ],
     )
-    x_sampler = fine.FineSampler(x_dist, mi_estimate_sample=_sample)
+    x_sampler = bmm.FineSampler(x_dist, mi_estimate_sample=_sample)
     return ExampleDistribution(dist=x_dist, sampler=x_sampler)
 
 
 def create_galaxy_distribution(_sample: int = 100) -> ExampleDistribution:
     """The Galaxy distribution."""
-    balls_mixt = fine.mixture(
+    balls_mixt = bmm.mixture(
         proportions=jnp.array([0.5, 0.5]),
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=bmi.samplers.canonical_correlation([0.0], additional_y=1),
                 mean=jnp.array([x, x, x]) * 1.5,
                 dim_x=2,
@@ -57,7 +57,7 @@ def create_galaxy_distribution(_sample: int = 100) -> ExampleDistribution:
         ],
     )
 
-    base_balls_sampler = fine.FineSampler(balls_mixt, mi_estimate_sample=_sample)
+    base_balls_sampler = bmm.FineSampler(balls_mixt, mi_estimate_sample=_sample)
     a = jnp.array([[0, -1], [1, 0]])
     spiral = bmi.transforms.Spiral(a, speed=0.5)
 
@@ -74,36 +74,36 @@ def create_ai_distribution(_sample: int = 100) -> ExampleDistribution:
     corr = 0.95
     var_x = 0.04
 
-    ai_dist = fine.mixture(
+    ai_dist = bmm.mixture(
         proportions=jnp.full(6, fill_value=1 / 6),
         components=[
             # I components
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([1.0, 0.0]),
                 covariance=np.diag([0.01, 0.2]),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([1.0, 1]),
                 covariance=np.diag([0.05, 0.001]),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([1.0, -1]),
                 covariance=np.diag([0.05, 0.001]),
             ),
             # A components
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([-0.8, -0.2]),
                 covariance=np.diag([0.03, 0.001]),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([-1.2, 0.0]),
@@ -111,7 +111,7 @@ def create_ai_distribution(_sample: int = 100) -> ExampleDistribution:
                     [[var_x, jnp.sqrt(var_x * 0.2) * corr], [jnp.sqrt(var_x * 0.2) * corr, 0.2]]
                 ),
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 dim_x=1,
                 dim_y=1,
                 mean=jnp.array([-0.4, 0.0]),
@@ -121,7 +121,7 @@ def create_ai_distribution(_sample: int = 100) -> ExampleDistribution:
             ),
         ],
     )
-    ai_sampler = fine.FineSampler(ai_dist, mi_estimate_sample=_sample)
+    ai_sampler = bmm.FineSampler(ai_dist, mi_estimate_sample=_sample)
     return ExampleDistribution(dist=ai_dist, sampler=ai_sampler)
 
 
@@ -129,10 +129,10 @@ def create_waves_distribution(n_components: int = 12, _sample: int = 100) -> Exa
     """The Waves distribution."""
     assert n_components > 0
 
-    fence_base_dist = fine.mixture(
+    fence_base_dist = bmm.mixture(
         proportions=jnp.ones(n_components) / n_components,
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=jnp.diag(jnp.array([0.1, 1.0, 0.1])),
                 mean=jnp.array([x, 0, x % 4]) * 1.5,
                 dim_x=2,
@@ -141,7 +141,7 @@ def create_waves_distribution(n_components: int = 12, _sample: int = 100) -> Exa
             for x in range(n_components)
         ],
     )
-    base_sampler = fine.FineSampler(fence_base_dist, mi_estimate_sample=_sample)
+    base_sampler = bmm.FineSampler(fence_base_dist, mi_estimate_sample=_sample)
     fence_aux_sampler = bmi.samplers.TransformedSampler(
         base_sampler,
         transform_x=lambda x: x + jnp.array([5.0, 0.0]) * jnp.sin(3 * x[1]),

--- a/workflows/projects/Mixtures/example_distributions.py
+++ b/workflows/projects/Mixtures/example_distributions.py
@@ -38,7 +38,7 @@ def create_x_distribution(_sample: int = 100) -> ExampleDistribution:
             for x in [-1, 1]
         ],
     )
-    x_sampler = bmm.FineSampler(x_dist, mi_estimate_sample=_sample)
+    x_sampler = bmm.BMMSampler(x_dist, mi_estimate_sample=_sample)
     return ExampleDistribution(dist=x_dist, sampler=x_sampler)
 
 
@@ -57,7 +57,7 @@ def create_galaxy_distribution(_sample: int = 100) -> ExampleDistribution:
         ],
     )
 
-    base_balls_sampler = bmm.FineSampler(balls_mixt, mi_estimate_sample=_sample)
+    base_balls_sampler = bmm.BMMSampler(balls_mixt, mi_estimate_sample=_sample)
     a = jnp.array([[0, -1], [1, 0]])
     spiral = bmi.transforms.Spiral(a, speed=0.5)
 
@@ -121,7 +121,7 @@ def create_ai_distribution(_sample: int = 100) -> ExampleDistribution:
             ),
         ],
     )
-    ai_sampler = bmm.FineSampler(ai_dist, mi_estimate_sample=_sample)
+    ai_sampler = bmm.BMMSampler(ai_dist, mi_estimate_sample=_sample)
     return ExampleDistribution(dist=ai_dist, sampler=ai_sampler)
 
 
@@ -141,7 +141,7 @@ def create_waves_distribution(n_components: int = 12, _sample: int = 100) -> Exa
             for x in range(n_components)
         ],
     )
-    base_sampler = bmm.FineSampler(fence_base_dist, mi_estimate_sample=_sample)
+    base_sampler = bmm.BMMSampler(fence_base_dist, mi_estimate_sample=_sample)
     fence_aux_sampler = bmi.samplers.TransformedSampler(
         base_sampler,
         transform_x=lambda x: x + jnp.array([5.0, 0.0]) * jnp.sin(3 * x[1]),

--- a/workflows/projects/Mixtures/fitting_gmm.smk
+++ b/workflows/projects/Mixtures/fitting_gmm.smk
@@ -13,7 +13,7 @@ import numpyro.distributions as dist
 from numpyro.infer import MCMC, NUTS
 
 import bmi
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 from subplots_from_axsize import subplots_from_axsize
 
@@ -85,8 +85,8 @@ def sample_into_fine_distribution(
     proportions: jnp.ndarray,
     dim_x: int,
     dim_y: int,
-) -> fine.JointDistribution:
-    """Builds a fine distribution from a Gaussian mixture model parameters."""
+) -> bmm.JointDistribution:
+    """Builds a BMM from a Gaussian mixture model parameters."""
     # Check if the dimensions are right
     n_components = proportions.shape[0]
     n_dims = dim_x + dim_y
@@ -95,7 +95,7 @@ def sample_into_fine_distribution(
     
     # Build components
     components = [
-        fine.MultivariateNormalDistribution(
+        bmm.MultivariateNormalDistribution(
             dim_x=dim_x,
             dim_y=dim_y,
             mean=mean,
@@ -105,7 +105,7 @@ def sample_into_fine_distribution(
     ]
 
     # Build a mixture model
-    return fine.mixture(proportions=proportions, components=components)
+    return bmm.mixture(proportions=proportions, components=components)
 
 DISTRIBUTIONS = {
     "Galaxy": ed.create_galaxy_distribution(_sample=3),

--- a/workflows/projects/Mixtures/fitting_gmm.smk
+++ b/workflows/projects/Mixtures/fitting_gmm.smk
@@ -79,7 +79,7 @@ def model(data, K: int = 10, alpha: Optional[float] = None, jitter: float = 1e-6
         obs=data)
 
 
-def sample_into_fine_distribution(
+def sample_into_bmm_distribution(
     means: jnp.ndarray,
     covariances: jnp.ndarray,
     proportions: jnp.ndarray,
@@ -286,7 +286,7 @@ rule create_approx_sample:
         
         idx = int(wildcards.sample_index)
 
-        approx_dist = sample_into_fine_distribution(
+        approx_dist = sample_into_bmm_distribution(
             means=samples["mu"][idx],
             covariances=samples["cov"][idx],
             proportions=samples["pi"][idx],
@@ -311,7 +311,7 @@ rule estimate_pmi_in_sample:
         
         idx = int(wildcards.sample_index)
 
-        approx_dist = sample_into_fine_distribution(
+        approx_dist = sample_into_bmm_distribution(
             means=samples["mu"][idx],
             covariances=samples["cov"][idx],
             proportions=samples["pi"][idx],

--- a/workflows/projects/Mixtures/outliers.smk
+++ b/workflows/projects/Mixtures/outliers.smk
@@ -75,7 +75,7 @@ MIXING_TASKS = {}
 # Add mixing tasks
 for setup_name, setup in CHANGE_MIXING_SETUPS.items():
     for alpha in ALPHAS:
-        sampler = bmm.FineSampler(dist=setup.mixture(alpha=alpha), mi_estimate_sample=100_000)
+        sampler = bmm.BMMSampler(dist=setup.mixture(alpha=alpha), mi_estimate_sample=100_000)
         task = bmi.Task(
             sampler=sampler,
             task_id=f"mixing-{setup_name}-{alpha}",
@@ -95,7 +95,7 @@ for variance in VARIANCES:
             covariance=variance * jnp.eye(dist_signal_gauss.dim_y)
         ),
     )
-    sampler = bmm.FineSampler(
+    sampler = bmm.BMMSampler(
         dist=bmm.mixture(
             proportions=jnp.array([1.0-VARIANCE_MIXING, VARIANCE_MIXING]),
             components=[dist_signal_gauss, dist_noise_variance],

--- a/workflows/projects/Mixtures/visualizing_critics.py
+++ b/workflows/projects/Mixtures/visualizing_critics.py
@@ -52,9 +52,9 @@ infonce = bmi.estimators.neural.InfoNCEEstimator(
 #     dim_x=1, dim_y=1, df=1,
 # )
 
-# sampler_student = bmm.FineSampler(dist_student)
+# sampler_student = bmm.BMMSampler(dist_student)
 
-# sampler_student_arcsinh = bmm.FineSampler(bmm.transform(
+# sampler_student_arcsinh = bmm.BMMSampler(bmm.transform(
 #     dist_student,
 #     x_transform=arcsinh_bijector,
 #     y_transform=arcsinh_bijector,
@@ -63,7 +63,7 @@ infonce = bmi.estimators.neural.InfoNCEEstimator(
 # print(f"MI = {sampler_student.mutual_information():.4f}")
 
 # +
-sampler_four_balls = bmm.FineSampler(
+sampler_four_balls = bmm.BMMSampler(
     bmm.mixture(
         proportions=jnp.array([0.3, 0.3, 0.2, 0.2]),
         components=[

--- a/workflows/projects/Mixtures/visualizing_critics.py
+++ b/workflows/projects/Mixtures/visualizing_critics.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 from subplots_from_axsize import subplots_from_axsize
 
 import bmi
-from bmi.samplers import fine
+from bmi.samplers import bmm
 
 # -
 
@@ -46,15 +46,15 @@ infonce = bmi.estimators.neural.InfoNCEEstimator(
 # arcsinh_bijector = tfp.bijectors.Invert(tfp.bijectors.Sinh())
 
 # +
-# dist_student = fine.MultivariateStudentDistribution(
+# dist_student = bmm.MultivariateStudentDistribution(
 #     dispersion=0.1 * jnp.eye(2),
 #     mean=jnp.array([0., 0.]),
 #     dim_x=1, dim_y=1, df=1,
 # )
 
-# sampler_student = fine.FineSampler(dist_student)
+# sampler_student = bmm.FineSampler(dist_student)
 
-# sampler_student_arcsinh = fine.FineSampler(fine.transform(
+# sampler_student_arcsinh = bmm.FineSampler(bmm.transform(
 #     dist_student,
 #     x_transform=arcsinh_bijector,
 #     y_transform=arcsinh_bijector,
@@ -63,29 +63,29 @@ infonce = bmi.estimators.neural.InfoNCEEstimator(
 # print(f"MI = {sampler_student.mutual_information():.4f}")
 
 # +
-sampler_four_balls = fine.FineSampler(
-    fine.mixture(
+sampler_four_balls = bmm.FineSampler(
+    bmm.mixture(
         proportions=jnp.array([0.3, 0.3, 0.2, 0.2]),
         components=[
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=bmi.samplers.canonical_correlation([0.0]),
                 mean=jnp.array([-1.25, -1.25]),
                 dim_x=1,
                 dim_y=1,
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=bmi.samplers.canonical_correlation([0.0]),
                 mean=jnp.array([+1.25, +1.25]),
                 dim_x=1,
                 dim_y=1,
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=0.2 * bmi.samplers.canonical_correlation([0.0]),
                 mean=jnp.array([-2.5, +2.5]),
                 dim_x=1,
                 dim_y=1,
             ),
-            fine.MultivariateNormalDistribution(
+            bmm.MultivariateNormalDistribution(
                 covariance=0.2 * bmi.samplers.canonical_correlation([0.0]),
                 mean=jnp.array([+2.5, -2.5]),
                 dim_x=1,


### PR DESCRIPTION
@grfrederic This is an ongoing effort to replace fine distributions with BMMs (as described in #143). This requires considerable changes:

- [x] Update the imports in `src/` (and make sure that the `tests/` pass as they will also have to be updated.)
- [x] Update the names, such as `FineSampler` to `BMMSampler`.
- [x] Update the snakemake workflows (this is **very important!**)
- [x] Revise the documentation on fine distributions. Check if API is rendered properly.

Advice, comments, or changes pushed to this branch are welcome :slightly_smiling_face: 